### PR TITLE
ci: tee configure.log so a configure failure is debuggable

### DIFF
--- a/movfuscator-wasm/scripts/build-wasm-as.sh
+++ b/movfuscator-wasm/scripts/build-wasm-as.sh
@@ -48,6 +48,9 @@ if [ ! -f Makefile ]; then
     # to run on the build machine, not the wasm target. emconfigure sets
     # CC=emcc but leaves CC_FOR_BUILD inheriting the same value unless
     # we override it.
+    # tee instead of plain `> configure.log` so a configure failure
+    # surfaces in CI logs (otherwise `make: Error 1` from this step is
+    # opaque — happened on the first post-merge deploy run).
     emconfigure "$src/configure" \
         --target=i386-linux-gnu \
         --disable-werror --disable-nls --disable-shared \
@@ -59,7 +62,7 @@ if [ ! -f Makefile ]; then
         --disable-bootstrap \
         --without-zlib --without-zstd \
         CC_FOR_BUILD=cc \
-        > configure.log 2>&1
+        2>&1 | tee configure.log
 fi
 
 # Belt + suspenders for build-time helpers. configure-side CC_FOR_BUILD

--- a/movfuscator-wasm/scripts/build-wasm-as.sh
+++ b/movfuscator-wasm/scripts/build-wasm-as.sh
@@ -51,7 +51,13 @@ if [ ! -f Makefile ]; then
     # tee instead of plain `> configure.log` so a configure failure
     # surfaces in CI logs (otherwise `make: Error 1` from this step is
     # opaque — happened on the first post-merge deploy run).
+    # --host=wasm32-unknown-emscripten makes autoconf treat this as a
+    # cross-build (build != host), skipping the "can we run a compiled
+    # program?" check that otherwise fails with emcc-produced wasm.
+    # emconfigure sets CC=emcc but doesn't pass --host on its own, so
+    # binutils' configure would see the native build triple and crash.
     emconfigure "$src/configure" \
+        --host=wasm32-unknown-emscripten \
         --target=i386-linux-gnu \
         --disable-werror --disable-nls --disable-shared \
         --disable-gold --disable-gdb --disable-gdbserver \


### PR DESCRIPTION
## Summary
- `build-wasm-as.sh` redirected `emconfigure` stdout+stderr to `configure.log` with `> configure.log 2>&1`. On failure, the only thing the CI step prints is `make: *** [Makefile:51: build-wasm-as] Error 1` — opaque.
- First post-merge deploy on `mov` (run [26374375000](https://github.com/sksat/x86.mov/actions/runs/26374375000)) hit a transient configure flake and showed exactly that. A `workflow_dispatch` re-run passed, so production is up to date, but the next flake would be just as blind.
- Switch to `2>&1 | tee configure.log` so output flows to the CI log *and* is still archived locally — matches what the script already does for the `emmake` step.

## Test plan
- [ ] CI passes (this branch exercises the same `build-wasm-as` step that flaked yesterday).