### PR TITLE
llvm-mov: opt 6 follow-up — Phase 5 idx-zero hoist for shift32rCL

### DIFF
--- a/llvm-mov/bench/fixtures/shift_reg.c
+++ b/llvm-mov/bench/fixtures/shift_reg.c
@@ -1,0 +1,36 @@
+/* opt 6 follow-up visibility — register-amount shifts (`x << n`,
+ * `x >> n` where `n` is a runtime value). The signed shifts lower
+ * to SHL32rCL and SAR32rCL; the unsigned `>>` is what surfaces
+ * SHR32rCL specifically. All three flow through the same heavy
+ * mov-only rewrite — `legalizeShift32rCL`, a 5-stage power-of-2
+ * unroll that historically emitted 50 redundant `mov dword [idx],
+ * 0` instructions per site. The "Phase 5 idx-zero hoist" follow-up
+ * to opt 6 turns those 50 into 1 (the invariant is identical to
+ * opt 6's CMP+Jcc Phase 5 hoist: nothing inside the unrolled loop
+ * writes idx[2..3], so a single hoisted MOV32mi is enough).
+ *
+ * `argc` keeps the LHS runtime so DAGCombine can't fold the shift;
+ * the amount is also derived from `argc` so it stays in CL and we
+ * hit the rCL path, not the ri path. Combining SHL (`<<`), SAR
+ * (signed `>>`), and SHR (unsigned `>>` on `unsigned int`) in the
+ * same fixture exercises all three legalize entry points and lets
+ * the bench surface the per-site savings in one row.
+ *
+ * C89 (declarations before statements) — movfuscator's LCC
+ * frontend rejects mixed declarations, and we keep the fixture
+ * apples-to-apples across the bench backends.
+ */
+int main(int argc, char **argv) {
+    int x;
+    int y;
+    int s;
+    unsigned u;
+    int amt;
+    (void)argv;
+    amt = argc & 7;             /* runtime amount, kept in [0, 7] */
+    x = argc << amt;            /* SHL32rCL */
+    y = (x | 0x32);
+    s = y >> amt;               /* SAR32rCL (signed int >>) */
+    u = (unsigned)y >> amt;     /* SHR32rCL (unsigned >>) */
+    return (s ^ (int)u) | (y & 0xFF);
+}

--- a/llvm-mov/bench/results.md
+++ b/llvm-mov/bench/results.md
@@ -5,7 +5,7 @@ ELF artifact of compiling the same C source through both
 back-ends. Sizes are in bytes (`stat`/`readelf`); mov ratio is
 `mov-family mnemonic count` / `total mnemonic count` in `.text`._
 
-Generated 2026-05-28T04:17:31Z on x86_64 (Linux).
+Generated 2026-05-28T21:10:21Z on x86_64 (Linux).
 
 ## return0
 
@@ -20,7 +20,7 @@ int main(void) { return 0; }
 | .rodata size | 524288 | 0 | 0 | 0 | 0 | 0 |
 | mov count / total | 120 / 123 (97.6%) | 775 / 777 (99.7%) | 4 / 13 (30.8%) | 2 / 7 (28.6%) | 2 / 7 (28.6%) | 2 / 7 (28.6%) |
 | non-mov mnemonics | `call int jmp` | `call` | `add call int pop push ret xchg xor` | `call int ret xchg xor` | `call int ret xchg xor` | `call int ret xchg xor` |
-| wall-clock runtime (hyperfine mean) | 2.986 ms | 2.601 ms | 2.284 ms | 2.583 ms | 2.820 ms | 3.406 ms |
+| wall-clock runtime (hyperfine mean) | 1.656 ms | 3.611 ms | 1.478 ms | 0.473 ms | 2.874 ms | 1.203 ms |
 
 ## return42
 
@@ -35,7 +35,7 @@ int main(void) { return 42; }
 | .rodata size | 524288 | 0 | 0 | 0 | 0 | 0 |
 | mov count / total | 120 / 123 (97.6%) | 775 / 777 (99.7%) | 5 / 13 (38.5%) | 3 / 7 (42.9%) | 3 / 7 (42.9%) | 3 / 7 (42.9%) |
 | non-mov mnemonics | `call int jmp` | `call` | `add call int pop push ret xchg` | `call int ret xchg` | `call int ret xchg` | `call int ret xchg` |
-| wall-clock runtime (hyperfine mean) | 0.178 ms | 0.547 ms | 0.178 ms | 0.152 ms | 0.164 ms | 0.151 ms |
+| wall-clock runtime (hyperfine mean) | 0.410 ms | 1.536 ms | 0.789 ms | 0.818 ms | 0.629 ms | 0.360 ms |
 
 ## eq42
 
@@ -59,7 +59,7 @@ int main(void) {
 | .rodata size | 721152 | 0 | 0 | 0 | 0 | 0 |
 | mov count / total | 274 / 281 (97.5%) | 1050 / 1052 (99.8%) | 8 / 19 (42.1%) | 3 / 7 (42.9%) | 3 / 7 (42.9%) | 3 / 7 (42.9%) |
 | non-mov mnemonics | `call int jmp` | `call` | `add call cmp int jmp jne pop push ret sub xchg` | `call int ret xchg` | `call int ret xchg` | `call int ret xchg` |
-| wall-clock runtime (hyperfine mean) | 0.222 ms | 0.568 ms | 0.153 ms | 0.154 ms | 0.175 ms | 0.152 ms |
+| wall-clock runtime (hyperfine mean) | 0.672 ms | 1.050 ms | 0.384 ms | 0.715 ms | 0.410 ms | 1.188 ms |
 
 ## lt_unsigned
 
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
 | .rodata size | 721152 | 0 | 0 | 0 | 0 | 0 |
 | mov count / total | 304 / 311 (97.7%) | 1045 / 1047 (99.8%) | 9 / 20 (45.0%) | 2 / 9 (22.2%) | 2 / 9 (22.2%) | 2 / 9 (22.2%) |
 | non-mov mnemonics | `call int jmp` | `call` | `add call cmp int jae jmp pop push ret xchg` | `call cmp int ret setb xchg xor` | `call cmp int ret setb xchg xor` | `call cmp int ret setb xchg xor` |
-| wall-clock runtime (hyperfine mean) | 3.318 ms | 3.582 ms | 3.230 ms | 3.643 ms | 2.787 ms | 3.786 ms |
+| wall-clock runtime (hyperfine mean) | 1.539 ms | 2.772 ms | 0.856 ms | 2.431 ms | 1.432 ms | 1.832 ms |
 
 ## bitops
 
@@ -134,7 +134,7 @@ int main(void) {
 | .rodata size | 589824 | 0 | 0 | 0 | 0 | 0 |
 | mov count / total | 164 / 167 (98.2%) | 922 / 924 (99.8%) | 8 / 19 (42.1%) | 3 / 7 (42.9%) | 3 / 7 (42.9%) | 3 / 7 (42.9%) |
 | non-mov mnemonics | `call int jmp` | `call` | `add and call int or pop push ret sub xchg xor` | `call int ret xchg` | `call int ret xchg` | `call int ret xchg` |
-| wall-clock runtime (hyperfine mean) | 3.340 ms | 3.185 ms | 2.588 ms | 0.155 ms | 0.199 ms | 0.159 ms |
+| wall-clock runtime (hyperfine mean) | 1.609 ms | 1.891 ms | 1.446 ms | 0.740 ms | 2.298 ms | 1.207 ms |
 
 ## sum10
 
@@ -154,7 +154,7 @@ int main(void) {
 | .rodata size | 721408 | 0 | 0 | 0 | 0 | 0 |
 | mov count / total | 421 / 429 (98.1%) | 1225 / 1227 (99.8%) | 11 / 24 (45.8%) | 3 / 7 (42.9%) | 3 / 7 (42.9%) | 3 / 7 (42.9%) |
 | non-mov mnemonics | `call int jmp` | `call` | `add call cmp int jg jmp pop push ret sub xchg` | `call int ret xchg` | `call int ret xchg` | `call int ret xchg` |
-| wall-clock runtime (hyperfine mean) | 0.193 ms | 0.575 ms | 0.164 ms | 0.155 ms | 0.150 ms | 0.153 ms |
+| wall-clock runtime (hyperfine mean) | 0.633 ms | 2.071 ms | 0.500 ms | 0.402 ms | 0.304 ms | 0.343 ms |
 
 ## fib10
 
@@ -191,7 +191,7 @@ int main(void) {
 | .rodata size | 721408 | 0 | 0 | 0 | 0 | 0 |
 | mov count / total | 426 / 434 (98.2%) | 1267 / 1269 (99.8%) | 16 / 29 (55.2%) | 3 / 7 (42.9%) | 3 / 7 (42.9%) | 3 / 7 (42.9%) |
 | non-mov mnemonics | `call int jmp` | `call` | `add call cmp int jge jmp pop push ret sub xchg` | `call int ret xchg` | `call int ret xchg` | `call int ret xchg` |
-| wall-clock runtime (hyperfine mean) | 3.189 ms | 3.773 ms | 3.002 ms | 0.183 ms | 3.588 ms | 2.073 ms |
+| wall-clock runtime (hyperfine mean) | 2.614 ms | 2.436 ms | 0.604 ms | 1.133 ms | 3.164 ms | 2.340 ms |
 
 ## shifts
 
@@ -228,7 +228,57 @@ int main(int argc, char **argv) {
 | .rodata size | 657152 | 0 | 0 | 0 | 0 | 0 |
 | mov count / total | 458 / 461 (99.3%) | 1423 / 1425 (99.9%) | 14 / 28 (50.0%) | 3 / 9 (33.3%) | 3 / 9 (33.3%) | 3 / 9 (33.3%) |
 | non-mov mnemonics | `call int jmp` | `call` | `add and call int or pop push ret sar shl sub xchg` | `call int or ret shl xchg` | `call int or ret shl xchg` | `call int or ret shl xchg` |
-| wall-clock runtime (hyperfine mean) | 3.186 ms | 3.205 ms | 3.391 ms | 1.781 ms | 2.677 ms | 3.586 ms |
+| wall-clock runtime (hyperfine mean) | 1.319 ms | 1.788 ms | 0.670 ms | 0.598 ms | 1.771 ms | 0.998 ms |
+
+## shift_reg
+
+```c
+/* opt 6 follow-up visibility — register-amount shifts (`x << n`,
+ * `x >> n` where `n` is a runtime value). The signed shifts lower
+ * to SHL32rCL and SAR32rCL; the unsigned `>>` is what surfaces
+ * SHR32rCL specifically. All three flow through the same heavy
+ * mov-only rewrite — `legalizeShift32rCL`, a 5-stage power-of-2
+ * unroll that historically emitted 50 redundant `mov dword [idx],
+ * 0` instructions per site. The "Phase 5 idx-zero hoist" follow-up
+ * to opt 6 turns those 50 into 1 (the invariant is identical to
+ * opt 6's CMP+Jcc Phase 5 hoist: nothing inside the unrolled loop
+ * writes idx[2..3], so a single hoisted MOV32mi is enough).
+ *
+ * `argc` keeps the LHS runtime so DAGCombine can't fold the shift;
+ * the amount is also derived from `argc` so it stays in CL and we
+ * hit the rCL path, not the ri path. Combining SHL (`<<`), SAR
+ * (signed `>>`), and SHR (unsigned `>>` on `unsigned int`) in the
+ * same fixture exercises all three legalize entry points and lets
+ * the bench surface the per-site savings in one row.
+ *
+ * C89 (declarations before statements) — movfuscator's LCC
+ * frontend rejects mixed declarations, and we keep the fixture
+ * apples-to-apples across the bench backends.
+ */
+int main(int argc, char **argv) {
+    int x;
+    int y;
+    int s;
+    unsigned u;
+    int amt;
+    (void)argv;
+    amt = argc & 7;             /* runtime amount, kept in [0, 7] */
+    x = argc << amt;            /* SHL32rCL */
+    y = (x | 0x32);
+    s = y >> amt;               /* SAR32rCL (signed int >>) */
+    u = (unsigned)y >> amt;     /* SHR32rCL (unsigned >>) */
+    return (s ^ (int)u) | (y & 0xFF);
+}
+```
+
+| metric | llvm-mov | movfuscator | clang -O0 | clang -O1 | clang -O2 | clang -O3 |
+|---|---:|---:|---:|---:|---:|---:|
+| total ELF (bytes) | 741704 | 10225204 | 8824 | 8820 | 8820 | 8820 |
+| .text size | 8757 | 8274 | 108 | 48 | 48 | 48 |
+| .rodata size | 723968 | 0 | 0 | 0 | 0 | 0 |
+| mov count / total | 2378 / 2381 (99.9%) | 1542 / 1544 (99.9%) | 21 / 37 (56.8%) | 7 / 20 (35.0%) | 7 / 20 (35.0%) | 7 / 20 (35.0%) |
+| non-mov mnemonics | `call int jmp` | `call` | `add and call int or pop push ret sar shl shr sub xchg xor` | `and call int or pop push ret sar shl shr xchg xor` | `and call int or pop push ret sar shl shr xchg xor` | `and call int or pop push ret sar shl shr xchg xor` |
+| wall-clock runtime (hyperfine mean) | 3.895 ms | 2.224 ms | 0.659 ms | 1.466 ms | 1.585 ms | 0.925 ms |
 
 ## fib_rec
 
@@ -275,7 +325,7 @@ int main(void) {
 | .rodata size | 721408 | 0 | 0 | 0 | 0 | 0 |
 | mov count / total | 873 / 884 (98.8%) | 2248 / 2250 (99.9%) | 21 / 54 (38.9%) | 6 / 43 (14.0%) | 7 / 57 (12.3%) | 7 / 57 (12.3%) |
 | non-mov mnemonics | `call int jmp` | `call` | `add call cmp int jge jmp nop pop push ret sub xchg` | `add call cmp int jge jl lea nop pop push ret sub xchg xor` | `add call cmp int ja jl lea nop pop push ret sub xchg xor` | `add call cmp int ja jl lea nop pop push ret sub xchg xor` |
-| wall-clock runtime (hyperfine mean) | 87.366 ms | 1496.402 ms | 3.785 ms | 3.163 ms | 1.646 ms | 0.467 ms |
+| wall-clock runtime (hyperfine mean) | 432.875 ms | 3450.920 ms | 4.580 ms | 1.966 ms | 1.832 ms | 1.377 ms |
 
 ## multi_call
 
@@ -316,7 +366,7 @@ int main(int argc, char **argv) {
 | .rodata size | 524288 | 0 | 0 | 0 | 0 | 0 |
 | mov count / total | 704 / 711 (99.0%) | 2036 / 2038 (99.9%) | 22 / 46 (47.8%) | 4 / 22 (18.2%) | 4 / 22 (18.2%) | 4 / 22 (18.2%) |
 | non-mov mnemonics | `call int jmp` | `call` | `add call int nop pop push ret sub xchg` | `add call inc int lea nop ret xchg` | `add call inc int lea nop ret xchg` | `add call inc int lea nop ret xchg` |
-| wall-clock runtime (hyperfine mean) | 3.389 ms | 3.984 ms | 0.158 ms | 0.172 ms | 0.155 ms | 0.151 ms |
+| wall-clock runtime (hyperfine mean) | 0.201 ms | 1.338 ms | 0.919 ms | 1.412 ms | 1.716 ms | 0.605 ms |
 
 ## rust_main
 
@@ -351,7 +401,7 @@ pub extern "C" fn rust_main() -> i32 {
 | .rodata size | 524288 | — | 0 | 0 | 0 | 0 |
 | mov count / total | 193 / 199 (97.0%) | — | 3 / 7 (42.9%) | 3 / 7 (42.9%) | 3 / 7 (42.9%) | 3 / 7 (42.9%) |
 | non-mov mnemonics | `call int jmp` | — | `call int ret xchg` | `call int ret xchg` | `call int ret xchg` | `call int ret xchg` |
-| wall-clock runtime (hyperfine mean) | 3.991 ms | — | 3.873 ms | 3.985 ms | 2.926 ms | 2.788 ms |
+| wall-clock runtime (hyperfine mean) | 0.783 ms | — | 0.396 ms | 0.801 ms | 0.556 ms | 0.717 ms |
 
 ## rust_fib
 
@@ -402,5 +452,5 @@ pub extern "C" fn fib_main() -> i32 {
 | .rodata size | 721408 | — | 0 | 0 | 0 | 0 |
 | mov count / total | 939 / 953 (98.5%) | — | 20 / 50 (40.0%) | 6 / 41 (14.6%) | 7 / 50 (14.0%) | 7 / 50 (14.0%) |
 | non-mov mnemonics | `call int jmp` | — | `add call cmp int jl jmp pop push ret sub xchg` | `add call cmp int jge jl lea nop pop push ret sub xchg xor` | `add call cmp int ja jl lea nop pop push ret sub xchg xor` | `add call cmp int ja jl lea nop pop push ret sub xchg xor` |
-| wall-clock runtime (hyperfine mean) | 115.265 ms | — | 3.010 ms | 3.587 ms | 3.330 ms | 3.056 ms |
+| wall-clock runtime (hyperfine mean) | 257.238 ms | — | 1.540 ms | 1.810 ms | 2.621 ms | 2.763 ms |
 

--- a/llvm-mov/bench/run.sh
+++ b/llvm-mov/bench/run.sh
@@ -92,6 +92,14 @@ CLANG="${CLANG:-clang-22}"
 #   fib10             — small Fibonacci loop. ADD32rr chain + signed
 #                       compare; same story as sum10 but with an extra
 #                       loop carried dependency (a/b/t).
+#   shifts            — `<<`/`>>` with constant amounts. Exercises stage
+#                       7b2 (SHL32ri / SHR32ri byte-table rewrite).
+#   shift_reg         — `<<`/`>>` with a runtime amount, covering
+#                       SHL32rCL, SAR32rCL and SHR32rCL in one fixture.
+#                       Surfaces the opt-6-follow-up "Phase 5 idx-zero
+#                       hoist for shift32rCL": each shift site historically
+#                       paid 50 redundant `mov dword [idx], 0` stores;
+#                       with the hoist, 1.
 DEFAULT_FIXTURES=(
     return0
     return42
@@ -101,6 +109,7 @@ DEFAULT_FIXTURES=(
     sum10
     fib10
     shifts
+    shift_reg
     fib_rec
     multi_call
 )

--- a/llvm-mov/llvm/MovOnlyLegalize.cpp
+++ b/llvm-mov/llvm/MovOnlyLegalize.cpp
@@ -2484,8 +2484,12 @@ private:
   //      the result back to srcdst[ByteIdx].
   //
   // After this returns, srcdst[ByteIdx] holds the final result byte.
-  // ECX/DL/CL are trashed. idx is left in a clobbered state (the
-  // caller's next byte-stage zero pass resets it).
+  // ECX/DL/CL are trashed. idx[0..1] is left in a clobbered state
+  // (the caller writes idx[0..1] before its next table lookup).
+  // idx[2..3] is preserved as 0 throughout — this helper never
+  // writes them, so callers that established the invariant up
+  // front (e.g. opt 6 / opt 6 follow-up hoists) keep it across
+  // repeated invocations.
   static void emitOrByteAndStore(MachineBasicBlock &MBB,
                                  MachineBasicBlock::iterator I,
                                  const DebugLoc &DL,
@@ -2502,9 +2506,11 @@ private:
     // mov byte ptr [idx + 1], cl       ; idx[1] = low_contrib
     BuildMI(MBB, I, DL, TII.get(Mov::MOV8mr))
         .addReg(Mov::EBP).addImm(A.IdxDisp + 1).addReg(Mov::CL);
-    // idx[2..3] are 0 from the previous lookup's `mov [idx], ecx`
-    // zero pass (the last write to idx[2..3] before this point is
-    // the one in emitUnaryByteLookup, which set them to 0).
+    // idx[2..3] are 0 — guaranteed by the caller's hoisted
+    // emitIdxZero (opt 6 / opt 6 follow-up) plus the fact that
+    // nothing on the path to here writes them (emitUnaryByteLookup
+    // re-establishes the zero internally, emitOrByteAndStore only
+    // touches idx[0..1]).
     // mov ecx, dword ptr [idx]
     BuildMI(MBB, I, DL, TII.get(Mov::MOV32rm), Mov::ECX)
         .addReg(Mov::EBP).addImm(A.IdxDisp);
@@ -2812,6 +2818,23 @@ private:
         "__mov_shr_byte_7",
     };
 
+    // opt 6 follow-up — Phase 5 idx-zero hoist for shift32rCL (smart-friend
+    // follow-up to opt 6, see PR #6 Future work). The previous shape
+    // emitted 50 emitIdxZero calls per shift32rCL site: 2 in each
+    // stage's mask compute (Phase B) and 8 in each stage's per-byte
+    // select (Phase C1+C2), times 5 stages. All but the very first
+    // are redundant — every helper inside the loop writes only
+    // idx[0..1] (or pre-zeros idx[0..3] internally via
+    // emitUnaryByteLookup before its own table lookup), so idx[2..3]
+    // stay 0 across the entire 5-stage unroll. One hoisted
+    // emitIdxZero here is enough to establish the invariant.
+    //
+    // The SAR sign-byte block above runs emitUnaryByteLookup, which
+    // already does its own internal MOV32mi 0 — but that fires only
+    // on SAR, so the unconditional hoist below covers SHL/SHR/SAR
+    // uniformly. Saves 49 movs per shift32rCL site.
+    emitIdxZero(MBB, Insert, DL, TII, *Addr);
+
     // ===== 5-stage unroll =====
     for (unsigned k = 0; k < 5; ++k) {
       const unsigned ShiftAmount = 1u << k; // 1, 2, 4, 8, 16
@@ -2871,7 +2894,8 @@ private:
       BuildMI(MBB, Insert, DL, TII.get(Mov::MOV8rm), Mov::DL)
           .addReg(Mov::EBP).addImm(*Addr->AmountBufDisp);
       // 2. Pack (amount, 1<<k) into idx[1..0] and look up __mov_and8_table.
-      emitIdxZero(MBB, Insert, DL, TII, *Addr);
+      // (opt 6 follow-up: idx[2..3] are already 0 from the hoisted emitIdxZero
+      // before the for-loop, and no MI in this loop writes them.)
       BuildMI(MBB, Insert, DL, TII.get(Mov::MOV8mr))
           .addReg(Mov::EBP).addImm(Addr->IdxDisp + 1).addReg(Mov::DL);
       BuildMI(MBB, Insert, DL, TII.get(Mov::MOV8ri), Mov::DL)
@@ -2892,7 +2916,8 @@ private:
           .addReg(Mov::DL);
       // 5. Compute inv_mask = mask XOR 0xFF (using __mov_xor8_table)
       //    and stash at amount_buf[2].
-      emitIdxZero(MBB, Insert, DL, TII, *Addr);
+      // (opt 6 follow-up: emitUnaryByteLookup above leaves idx[2..3] = 0; the
+      // writes to idx[0..1] below are full overwrites.)
       BuildMI(MBB, Insert, DL, TII.get(Mov::MOV8mr))
           .addReg(Mov::EBP).addImm(Addr->IdxDisp + 1).addReg(Mov::DL);
       BuildMI(MBB, Insert, DL, TII.get(Mov::MOV8mi))
@@ -2915,7 +2940,8 @@ private:
       // in DL).
       for (unsigned i = 0; i < 4; ++i) {
         // (C1) Compute (~mask & srcdst[i]) → DL, stash to srcdst[i].
-        emitIdxZero(MBB, Insert, DL, TII, *Addr);
+        // (opt 6 follow-up: prior xor8 lookup left idx[2..3] = 0; the writes
+        // below fully overwrite idx[0..1].)
         // idx[1] = inv_mask
         BuildMI(MBB, Insert, DL, TII.get(Mov::MOV8rm), Mov::DL)
             .addReg(Mov::EBP).addImm(*Addr->AmountBufDisp + 2);
@@ -2938,7 +2964,8 @@ private:
             .addReg(Mov::DL);
 
         // (C2) Compute (mask & shifted_buf[i]) → DL.
-        emitIdxZero(MBB, Insert, DL, TII, *Addr);
+        // (opt 6 follow-up: C1's and8 lookup left idx[2..3] = 0; the writes
+        // below fully overwrite idx[0..1].)
         BuildMI(MBB, Insert, DL, TII.get(Mov::MOV8rm), Mov::DL)
             .addReg(Mov::EBP).addImm(*Addr->AmountBufDisp + 1);
         BuildMI(MBB, Insert, DL, TII.get(Mov::MOV8mr))


### PR DESCRIPTION
## 概要

PR #6 の Future work で smart-friend が提案していた **optional follow-up** 「Phase 5 idx-zero hoist を `legalizeShift32rCL` の per-byte select にも横展開」を実装する PR。opt 6 (CMP+Jcc Phase 5 idx-zero hoist) と完全に同型の不変条件で、`shift32rCL` 経路にだけ残っていた 49 個 / 1 site の redundant な `mov dword [idx], 0` を一掃する。

新しい hoist 不変条件は導入していない (opt 6 で既に証明済みのものをそのまま移植している)。

## 何を変えるか

`llvm/MovOnlyLegalize.cpp` の `legalizeShift32rCL` (5-stage power-of-2 unroll) は、1 stage あたり以下のように `emitIdxZero` を呼んでいた:

| 場所 | 個数 / stage |
|---|---:|
| Phase B mask compute (`__mov_and8_table` 入力 packing 前) | 1 |
| Phase B inv_mask compute (`__mov_xor8_table` 入力 packing 前) | 1 |
| Phase C1 per-byte select (`(~mask & srcdst[i])` 計算前) | 4 |
| Phase C2 per-byte select (`(mask & shifted_buf[i])` 計算前) | 4 |
| **stage 合計** | **10** |

これが 5 stage 走るので **1 site あたり 50 個の `mov dword [idx], 0`**。

### 不変条件 (opt 6 と同型)

- 5-stage unroll の中で `idx` を書く MI は **`idx[0]` と `idx[1]` しか触らない** — Phase B / C のインライン `MOV8mr`/`MOV8mi` は全部 `[idx+0]` または `[idx+1]` に対する完全上書き、`emitOrByteAndStore` も `idx[0..1]` のみ書く。
- ループ内で `emitUnaryByteLookup` を経由する path (Phase B の select_mask_table 経由) は、helper 内部で `MOV32mi 0` を発行して `idx[0..3]=0` を再確立してから `idx[0]=DL` を書く。helper の中で閉じている。

つまり、for-loop の **直前に 1 回だけ** `emitIdxZero` を hoist すれば `idx[2..3]=0` の不変条件がループ全体で保たれる。SAR sign-byte block (`emitUnaryByteLookup` を呼ぶので idx[2..3]=0 を別途確立する) の有無に関わらず安全。

結果として **per-site で 49 個の `MOV32mi` を削減**。

### `emitOrByteAndStore` のコメント更新

opt 6 / opt 6 follow-up の hoist 後は「idx[2..3] は caller の hoisted `emitIdxZero` で 0 が確立され、helper を跨いで 0 が保たれる」が新しい契約になるので、helper の docstring と `emitOrByteAndStore` 内のインラインコメントを反映するよう書き換えた。

## bench への可視化

CL-form shift を踏む bench fixture が今まで無く、既存の `shifts.c` は ri-form (constant amount) しか含んでいなかったので、bench-check の deterministic 列にこの最適化の効果が出なかった。`bench/fixtures/shift_reg.c` を新規追加して 1 fixture 内で 3 形 (SHL32rCL / SAR32rCL / SHR32rCL) すべてをカバーする:

```c
amt = argc & 7;             /* runtime amount */
x = argc << amt;            /* SHL32rCL */
s = y >> amt;               /* SAR32rCL (signed int >>) */
u = (unsigned)y >> amt;     /* SHR32rCL (unsigned >>) */
```

`amt` も `argc` 由来なので DAGCombine が定数畳み込みできず、必ず CL-form rCL path にハマる。C89 (declarations before statements) で書いて movfuscator の LCC frontend も通すことで side-by-side 比較可能。

### 数字

| metric | llvm-mov (hoist あり) | (hoist なし試算) | movfuscator |
|---|---:|---:|---:|
| `.text` size | 8757 | ~8757 + 3 × 49 = ~8904 | 8274 |
| mov count | 2378 | 2378 + 3 × 49 = 2525 | 1542 |
| mov ratio | 99.9 % | 99.9 % | 99.9 % |

3 site × 49 mov 削減 = 147 mov 削減。`shifts` (ri-form) と `shift_reg` (rCL-form) の対で stage 7b2 と 7b3 が独立して bench-check で監視されるようになった。

## commit 粒度

smart-friend のレビュー指摘で、過去 opt 1-6 と同じ粒度に揃えて **2 commit** に分けた:

1. `llvm-mov: opt 6 follow-up — Phase 5 idx-zero hoist for shift32rCL` — hoist 本体 (MovOnlyLegalize.cpp のみ、既存 bench は CL-form を使わないので bench/results.md 不変)
2. `llvm-mov: bench — add shift_reg fixture (CL-form shift visibility)` — fixture 新規 + DEFAULT_FIXTURES 追加 + bench/results.md 再生成

## code-review

- **codex review** (`codex review --uncommitted`): \"The code changes themselves appear consistent\" — blocking issue なし。P2 で 「worktree-local の vendor symlink を commit に含めないこと」のみ指摘 (対処済み、commit には入れていない)。
- **smart-friend** (codex gpt-5.5): correctness issue なし。\"`legalizeShift32rCL` の loop 内で `idx[2..3]` を書くのは `emitUnaryByteLookup` の全ゼロ再確立だけで、`emitOrByteAndStore`/select 側は `idx[0..1]` 完全上書きなので、SAR sign-byte block や EPILOGUE で破綻する経路はなさそう\"。指摘 2 件 (どちらも対応済み): (1) `emitOrByteAndStore` のコメントが古いまま → 更新、(2) 初版 fixture が signed `>>` (SAR) だけだったので "SHR32rCL" 主張がやや過剰 → unsigned `>>` を追加して SHL/SAR/SHR 3 形をカバー。

## 関連する Future work

PR #6 の Future work に残っている他の候補との関係:

- **opt 7 候補 (ADJCALLSTACKUP + 次の ADJCALLSTACKDOWN の peephole)** — 別 PR で取り組む予定。今回の hoist とは独立。
- **7d3 / ADJCALLSTACK の SUB byte chain** — smart-friend に聞いたところ「carry/borrow を idx[2] に入れるので同型ではなく、opt 6 の横展開ほど単純ではない」とのこと。別個の analysis が必要。
- **MUL / DIV / REM の byte-chain 化、CTPOP / CTLZ / CTTZ の 256-entry table** — `legalizeShift32rCL` とは独立した backend feature。

## test plan

- [x] `make build` (LLVM 22.1.x、apt.llvm.org)
- [x] `make test-exec` → 40 passed, 0 failed
- [x] `make test-mov-only` → 19 mov-only, 0 failed (`-verify-machineinstrs` 込み)
- [x] `make test-rust-example` → 8 例 (main / fib / png_header / jpeg_header / bmp_decode / base64_decode / qoi_decode / indirect_call) 全 PASS
- [x] `make bench` で `bench/results.md` を再生成、`make bench-check` の deterministic 列が一致
- [x] commit 1 単独 (hoist 本体) の状態で gate green + bench-check green (既存 fixture は CL-form を使わないので results.md は変わらない)
- [x] commit 2 の `bench/results.md` 再生成後も bench-check green
- [x] `shl_rCL` / `sar_rCL` / `shl_reg` / `ashr_reg` / `lshr_reg` の `.text` mov 数が 854→805 / 860→811 と 49 ずつ減少
- [x] codex review (--uncommitted) と smart-friend (gpt-5.5) の両方で correctness OK 判定 + 指摘事項対応済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)