### PR TITLE
movfuscator-wasm: make multi-source compileToElf produce a runnable ELF (#9)

### DIFF
--- a/movfuscator-wasm/movfuscator.mjs
+++ b/movfuscator-wasm/movfuscator.mjs
@@ -340,16 +340,16 @@ export async function link(objs, libs, opts = {}) {
  * @param {string | Record<string,string>} source
  *   - string: single .c. Equivalent to
  *     `link(await assemble(await compile(source, headers)), undefined, linkOpts)`.
- *   - Record<string,string>: multi-file. Each `[basename, .c text]` is
- *     compiled + assembled independently and the resulting .o set is
- *     handed to link() in iteration order. The `basename` shows up in
- *     the resulting ELF's `.symtab`.
+ *   - Record<string,string>: multi-file. Sources are concatenated into a
+ *     single translation unit (with `#line` markers preserving per-file
+ *     diagnostics), compiled once, and the resulting single .o is linked.
+ *     This sidesteps an upstream movfuscator cross-`.o` ABI bug — see
+ *     issue #9 / the comment in this function for the long story.
  * @param {Record<string,string>} [headers] `name.h` → content map shared
  *   across every .c in `source`. Header sidecars are staged in MEMFS root
  *   so `#include "name.h"` resolves.
  * @param {object} [linkOpts] forwarded to link() (`name`, `extraLibs`,
- *   `searchPaths`, `extraInputs`). With multi-file `source` the `name`
- *   option is ignored — basenames come from the source map.
+ *   `searchPaths`, `extraInputs`).
  * @returns {Promise<Uint8Array>} ELF32 executable bytes
  */
 export async function compileToElf(source, headers = {}, linkOpts = {}) {
@@ -359,13 +359,62 @@ export async function compileToElf(source, headers = {}, linkOpts = {}) {
     if (!source || typeof source !== 'object') {
         throw new TypeError('source must be a string or Record<string,string>');
     }
-    const objs = {};
-    for (const [name, src] of Object.entries(source)) {
-        assertSafeName(name, 'source basename');
-        objs[name.endsWith('.o') ? name : `${name}.o`] =
-            await assemble(await compile(src, headers));
+    const entries = Object.entries(source);
+    for (const [name] of entries) assertSafeName(name, 'source basename');
+    if (entries.length === 0) {
+        throw new TypeError('source must have at least one entry');
     }
-    return link(objs, undefined, linkOpts);
+    // Multi-source: amalgamate into one TU. Upstream movfuscator decides
+    // the internal-vs-external CALL protocol per translation unit
+    // (movfuscator.c:3538 — `ext = !s || s->sclass == EXTERN`). When two
+    // `.o`s defined in separate TUs reference each other, the caller
+    // emits the libc-style external-trampoline protocol while the callee
+    // waits on the internal compare protocol, and `master_loop`
+    // deadlocks. Routing every CALL through a single TU keeps both sides
+    // on the internal protocol — almost. The combine alone isn't enough:
+    // a leftover `extern int add(...)` declaration in one piece will
+    // still mark the symbol's sclass as EXTERN and re-trigger the bug
+    // even when the definition lives in the very same amalgam.
+    // Workaround: scan every source for top-level function definitions
+    // and prepend a non-`extern` prototype (`retType name();` K&R form)
+    // for each one. C allows a non-`extern` prototype to follow a later
+    // ANSI prototype with full args, and lcc treats the resulting symbol
+    // as non-EXTERN — which is exactly what we want at every CALL site.
+    const seen = new Set();
+    const shadowProtos = [];
+    for (const [, src] of entries) {
+        for (const def of scanDefinedFunctions(src)) {
+            if (seen.has(def.name)) continue;
+            seen.add(def.name);
+            shadowProtos.push(`${def.retType} ${def.name}();`);
+        }
+    }
+    const amalgam =
+        (shadowProtos.length ? shadowProtos.join('\n') + '\n' : '') +
+        entries
+            .map(([name, src]) => `#line 1 "${name}.c"\n${src}`)
+            .join('\n');
+    return link(await assemble(await compile(amalgam, headers)), undefined, linkOpts);
+}
+
+// Best-effort scanner for top-level function definitions in a `.c` source.
+// Matches the typical fixture style — `[storage/qualifier]* returnType name(args) {`
+// on a single line, no leading indentation. Misses K&R definitions, defs
+// whose header spans multiple lines, and function-pointer return types;
+// those aren't represented in our current fixtures and falling back to a
+// missing shadow on them just reproduces the original deadlock without
+// silently mis-compiling.
+function scanDefinedFunctions(src) {
+    const re = /^([A-Za-z_][\w\s*]*?)\b([A-Za-z_]\w*)\s*\([^)]*\)\s*\{/gm;
+    const defs = [];
+    let m;
+    while ((m = re.exec(src)) !== null) {
+        const retType = m[1].trim();
+        const name = m[2];
+        if (retType.length === 0) continue;
+        defs.push({ retType, name });
+    }
+    return defs;
 }
 
 /**

--- a/movfuscator-wasm/tests/run-multi.mjs
+++ b/movfuscator-wasm/tests/run-multi.mjs
@@ -11,7 +11,7 @@
 // + multi-<group>-helper.c) is linked together; the .o files come from
 // the committed tests/goldens-o/ tree.
 
-import { existsSync, readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, mkdtempSync, chmodSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -174,6 +174,46 @@ await runTest('compileToElf (multi-source)', async () => {
     if (!h || 'raw' in h) throw new Error(`unexpected ELF header: ${JSON.stringify(h)}`);
     if (h.type !== 'EXEC (executable)') throw new Error(`expected EXEC, got ${h.type}`);
     if (h.machine !== 'i386')          throw new Error(`expected i386, got ${h.machine}`);
+});
+
+// --- Test 5: compileToElf multi-source produces a runnable ELF ---
+//
+// Upstream movfuscator has a cross-`.o` ABI bug (issue #9): the caller
+// emits a libc-style external call protocol while the callee waits on
+// the internal compare protocol, so master_loop deadlocks. The wrapper
+// works around that for the multi-source compileToElf path by feeding a
+// single TU to the codegen, which keeps every CALL on the internal
+// protocol.
+//
+// Native-execution signal: the program must complete on its own (signal
+// === null). Upstream's crt0 exits with the dynamic linker's status —
+// typically 1, not main()'s return value — so we don't pin the exact
+// exit code, only that the process didn't have to be killed.
+await runTest('compileToElf (multi-source) runs natively without hanging', async () => {
+    const { compileToElf } = await import(wrapper);
+    const aSrc = readFileSync(join(root, 'tests/fixtures/multi-add.c'), 'utf8');
+    const bSrc = readFileSync(join(root, 'tests/fixtures/multi-add-helper.c'), 'utf8');
+    const elf = await compileToElf({
+        'multi-add': aSrc,
+        'multi-add-helper': bSrc,
+    });
+    const tmp = mkdtempSync(join(tmpdir(), 'movfuscator-multi-run-'));
+    const elfPath = join(tmp, 'multi-add.elf');
+    writeFileSync(elfPath, elf);
+    chmodSync(elfPath, 0o755);
+    const res = spawnSync(elfPath, [], { timeout: 5000, encoding: 'buffer' });
+    if (res.signal !== null) {
+        throw new Error(
+            `multi-add ELF was killed by ${res.signal} (timed out — cross-.o deadlock?)`
+            + `\n  ${elfPath}`,
+        );
+    }
+    if (typeof res.status !== 'number') {
+        throw new Error(
+            `multi-add ELF did not exit cleanly (status=${res.status}, signal=${res.signal})`
+            + `\n  ${elfPath}`,
+        );
+    }
 });
 
 console.log();


### PR DESCRIPTION
Closes #9 (option B at the wrapper level — no fixture changes).

## Summary

- 上流 movfuscator の cross-`.o` バグ ([movfuscator.c:3538](https://github.com/sksat/x86.mov/blob/mov/movfuscator-wasm/vendor/movfuscator/movfuscator/movfuscator.c#L3538) — `ext = !s || s->sclass == EXTERN`) で、 caller が libc-style external-trampoline 、 callee が internal compare protocol を待ち、 `master_loop` が deadlock する。 multi-add で再現。
- `compileToElf(Record<string,string>)` を **1 TU に amalgamate** してから codegen に渡すよう変更 (movfuscator.mjs)。すべての CALL が internal protocol で揃う。
- ただし plain concat だけでは不十分： amalgam 内に `extern int add(...)` が残ると CALL site で sclass=EXTERN になり同じ deadlock を踏む。 → 各 source を scan して top-level の function definition を拾い、 `retType name();` の K&R 形 (非 `extern`) prototype を amalgam 頭にぶら下げる。 lcc は後続の ANSI prototype と compatible に扱い、 symbol は非-EXTERN のままになる。
- `tests/run-multi.mjs` に **test 5** を追加 (TDD): multi-add fixture を `compileToElf` 経由でビルド → native exec → `signal === null` を assert。 `origin/mov` では 5 秒 SIGTERM、 本 PR 適用後は ~10 ms で自走終了。

## Why not B-2 / B-3

- B-2 (fixture をいじる): user の依頼により fixture には触れない方針。 `multi-add.c` + `multi-add-helper.c` のままで動くようにする。
- B-3 (link() に warning): `link()` 自体は仕様通り byte-identical を保つので警告は出さず、 ABI mismatch は compileToElf 側で吸収する。

## Behavioral notes

- `.o`-level の `link()` パス (test 1/2/3) は変更なし。 host `/usr/bin/ld` と byte-identical を維持。
- `compileToElf` の戻り値は単一 .o リンク済み ELF になる (旧: 2 .o リンク済み)。 ELF header level の test 4 は引き続き pass。
- amalgamate の前段 scanner は典型的な 1 行 def header を対象とした best-effort。 K&R def や複数行にまたがる def header は shadow されず、その場合は元の deadlock を再現する (silent miscompile はしない)。

## Test plan

ローカル (Debian 13, x86_64, 32-bit libc 入り):

- [x] `node tests/run-multi.mjs` → 5/5 pass (`origin/mov` では新 test 5 が SIGTERM で fail)
- [x] `./tests/run.sh` → 19/19 pass (.s byte-identical)
- [x] `./tests/run-as.sh` → 19/19 pass (.o byte-identical)
- [x] `./tests/run-ld.sh` → 17/17 pass (ELF byte-identical vs `/usr/bin/ld`)
- [x] `node tests/browser.mjs` → 55/55 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)