### PR TITLE
llvm-mov/wasm: deploy via zstd + fzstd fallback

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -191,7 +191,7 @@ jobs:
           path: |
             llvm-mov/wasm/build/clang.js
             llvm-mov/wasm/build/clang.wasm
-            llvm-mov/wasm/build/clang.wasm.part-*
+            llvm-mov/wasm/build/clang.wasm.zst
             llvm-mov/wasm/build/clang.wasm.hash
             llvm-mov/wasm/build/package.json
           key: clang-wasm-${{ runner.os }}-${{ hashFiles('llvm-mov/wasm/scripts/build-wasm-clang.sh', 'llvm-mov/wasm/scripts/build-wasm-llvm.sh', 'llvm-mov/wasm/scripts/fetch.sh') }}-v1

--- a/.github/workflows/llvm-mov-wasm.yaml
+++ b/.github/workflows/llvm-mov-wasm.yaml
@@ -110,7 +110,7 @@ jobs:
           path: |
             llvm-mov/wasm/build/clang.js
             llvm-mov/wasm/build/clang.wasm
-            llvm-mov/wasm/build/clang.wasm.part-*
+            llvm-mov/wasm/build/clang.wasm.zst
             llvm-mov/wasm/build/clang.wasm.hash
             llvm-mov/wasm/build/package.json
           key: clang-wasm-${{ runner.os }}-${{ hashFiles('llvm-mov/wasm/scripts/build-wasm-clang.sh', 'llvm-mov/wasm/scripts/build-wasm-llvm.sh', 'llvm-mov/wasm/scripts/fetch.sh') }}-v1
@@ -145,3 +145,12 @@ jobs:
 
       - name: test-e2e (playwright + headless Chromium)
         run: make test-e2e
+
+      # Run the same Playwright suite against the staged dist tree
+      # served by a `_headers`-respecting Node server, so the
+      # Content-Encoding: zstd path (clang.wasm-{hash}.zst →
+      # decompress) is exercised on every push — that's the prod
+      # shape, and a regression there (e.g. window-size > 8 MiB)
+      # only ever fires under that codepath.
+      - name: test-e2e-dist (staged deploy + Content-Encoding: zstd)
+        run: make test-e2e-dist

--- a/llvm-mov/wasm/Makefile
+++ b/llvm-mov/wasm/Makefile
@@ -10,7 +10,7 @@ BUILD_DIR     ?= build
 
 .PHONY: help setup build build-wasm-llvm build-wasm-clang \
         build-wasm-llvm-mov-llc build-native-llvm-mov-llc \
-        test test-e2e stage-deploy serve clean distclean
+        test test-e2e test-e2e-dist stage-deploy serve clean distclean
 
 help:
 	@echo "Targets:"
@@ -23,6 +23,8 @@ help:
 	@echo "  test                        parity test: wasm .s vs native .s (per fixture)"
 	@echo "  test-e2e                    playwright: drive the demo page in a headless browser"
 	@echo "                              and diff the rendered .s against native (needs npm + browsers)"
+	@echo "  test-e2e-dist               same as test-e2e but against the staged ../../dist/ via a"
+	@echo "                              _headers-respecting Node server — exercises the zstd path"
 	@echo "  stage-deploy                stage ../../dist/llvm-mov/ for Cloudflare Pages"
 	@echo "  serve                       static-serve the demo on \$$PORT (default 8087)"
 	@echo "  clean                       remove $(BUILD_DIR)"
@@ -83,6 +85,16 @@ test-e2e: build
 	@if [ ! -d node_modules/@playwright ]; then npm install; fi
 	@npx playwright install chromium >/dev/null 2>&1 || true
 	npx playwright test
+
+# Same as test-e2e but the webServer reads from `../../dist/` and
+# applies the `_headers` rules. The wrapper sees `CLANG_WASM_VERSION`
+# set in the staged wasm-config.js and fetches `clang.wasm-{hash}.zst`
+# with `Content-Encoding: zstd`, which exercises the production-shape
+# loader path. The same demo.spec.js runs against this baseURL.
+test-e2e-dist: stage-deploy
+	@if [ ! -d node_modules/@playwright ]; then npm install; fi
+	@npx playwright install chromium >/dev/null 2>&1 || true
+	E2E_SERVE_DIST=1 npx playwright test
 
 # Same shape as ../../movfuscator-wasm/scripts/stage-deploy.sh — copies
 # the browser-loadable artifacts + the demo index.html into

--- a/llvm-mov/wasm/Makefile
+++ b/llvm-mov/wasm/Makefile
@@ -102,7 +102,12 @@ test-e2e-dist: stage-deploy
 # (The URL subpath stays as `llvm-mov`, even though the source tree
 # moved to llvm-mov/wasm/, because the deploy is the front door for the
 # subproject.)
+#
+# fzstd (the in-browser zstd fallback) lives in node_modules/, so
+# install if missing — keeps both local `make stage-deploy` and the
+# CI deploy job self-sufficient without a separate `npm ci` step.
 stage-deploy: build
+	@if [ ! -d node_modules/fzstd ]; then npm install; fi
 	./scripts/stage-deploy.sh
 
 PORT ?= 8087

--- a/llvm-mov/wasm/index.html
+++ b/llvm-mov/wasm/index.html
@@ -133,9 +133,12 @@ function setStatus(text) {
 }
 
 // Labels for stage breakdown rendered below the status line. Order
-// matters: it's the visual order in the timing element.
+// matters: it's the visual order in the timing element. The
+// `decompress-clang` stage only shows up on browsers without native
+// `Content-Encoding: zstd` (modern Chromium/Firefox/Edge skip it).
 const STAGE_LABEL = {
     'fetch-clang':       'fetch clang',
+    'decompress-clang':  'decompress clang',
     'instantiate-clang': 'instantiate clang',
     'compile-c':         'compile c→ir',
     'instantiate-llc':   'instantiate llc',
@@ -191,16 +194,21 @@ function fmtMB(bytes) {
 function statusFor(ev) {
     switch (ev.stage) {
         case 'fetch-clang': {
-            // The chunk-count line ticks slowly (4 chunks total); the
-            // bytes line ticks ~20 Hz with progress info from each
-            // active stream. Pre-header (totalBytes === 0) we just show
-            // the chunk count so the user sees motion immediately.
+            // The deploy ships clang.wasm as a zstd-compressed file.
+            // On browsers with native `Content-Encoding: zstd`,
+            // `bytes` is the running decompressed-byte count and
+            // `totalBytes` is the compressed `Content-Length` — i.e.
+            // the percentage tends >100% as decompression races
+            // ahead of the wire counter. The user-visible signal is
+            // "stuff is happening at network speed"; the literal
+            // percentage matters less.
             if (ev.totalBytes > 0) {
                 const pct = ((ev.bytes / ev.totalBytes) * 100).toFixed(0);
-                return `fetching clang.wasm chunks ${ev.done}/${ev.total} — ${fmtMB(ev.bytes)} / ${fmtMB(ev.totalBytes)} MiB (${pct}%)…`;
+                return `fetching clang.wasm — ${fmtMB(ev.bytes)} MiB (${pct}% of ${fmtMB(ev.totalBytes)} MiB wire)…`;
             }
-            return `fetching clang.wasm chunks ${ev.done}/${ev.total}…`;
+            return `fetching clang.wasm — ${fmtMB(ev.bytes)} MiB…`;
         }
+        case 'decompress-clang':  return 'decompressing clang.wasm (zstd)…';
         case 'instantiate-clang': return 'instantiating clang…';
         case 'compile-c':         return 'compiling C → LLVM IR…';
         case 'instantiate-llc':   return 'instantiating llvm-mov-llc…';

--- a/llvm-mov/wasm/llvm-mov.d.ts
+++ b/llvm-mov/wasm/llvm-mov.d.ts
@@ -1,20 +1,26 @@
 /**
  * Status event emitted by `onProgress` callbacks. Stages:
- *  - `fetch-clang`: a clang.wasm chunk fetch made progress. Throttled
- *    to ~20 Hz on the wire; an initial event with all zeros fires
- *    before the first byte lands. Only emitted when the deploy uses
- *    chunked artefacts.
- *    - `done`/`total`: chunks completed / chunks total.
- *    - `bytes`/`totalBytes`: bytes downloaded so far / sum of all
- *      chunks' `Content-Length` (may be 0 until the first response
- *      header arrives).
+ *  - `fetch-clang`: progress streaming the zstd-encoded
+ *    clang.wasm-{version}.zst from the deploy. Throttled to ~20 Hz
+ *    on the wire; an initial event with all zeros fires before the
+ *    first byte lands. Only emitted when the deploy is in use
+ *    (`CLANG_WASM_VERSION` non-null in `wasm-config.js`).
+ *    - `bytes`: bytes received so far. Equal to wire bytes when the
+ *      browser is decompressing zstd natively, otherwise compressed
+ *      bytes that will get decompressed on the JS side after fetch.
+ *    - `totalBytes`: server's `Content-Length` (0 until the response
+ *      header lands).
+ *  - `decompress-clang`: fzstd is about to run on the compressed
+ *    bytes. Only fires on browsers without native `Content-Encoding:
+ *    zstd` support.
  *  - `instantiate-clang` / `instantiate-llc`: the Emscripten module
  *    is about to be instantiated.
  *  - `compile-c`: clang's main() is about to run (C → LLVM IR).
  *  - `compile-ir`: llvm-mov-llc's main() is about to run (IR → asm).
  */
 export type ProgressEvent =
-    | { stage: 'fetch-clang'; done: number; total: number; bytes: number; totalBytes: number }
+    | { stage: 'fetch-clang'; bytes: number; totalBytes: number }
+    | { stage: 'decompress-clang' }
     | { stage: 'instantiate-clang' }
     | { stage: 'instantiate-llc' }
     | { stage: 'compile-c' }

--- a/llvm-mov/wasm/llvm-mov.mjs
+++ b/llvm-mov/wasm/llvm-mov.mjs
@@ -16,7 +16,7 @@
 // non-reusable. Same shape as movfuscator-wasm's wrappers.
 
 import createMovLlc from './build/llvm-mov-llc.js';
-import { CLANG_WASM_CHUNKS, CLANG_WASM_VERSION } from './wasm-config.js';
+import { CLANG_WASM_VERSION } from './wasm-config.js';
 
 // Clang is lazy-loaded so callers who only need `.ll → .s` (i.e. the
 // `compile()` API) can run without the 80 MB clang.wasm artifact
@@ -30,95 +30,116 @@ async function loadClang() {
     return _createMovClang;
 }
 
-// Cloudflare Pages rejects single files larger than 25 MiB at upload.
-// The deploy splits clang.wasm into `CLANG_WASM_CHUNKS` smaller
-// `clang.wasm.part-N` files; we fetch them in parallel, concatenate,
-// and feed the bytes to Emscripten via `Module.wasmBinary` (which
-// suppresses the default `clang.wasm` fetch). When the const is null
-// (the committed default — i.e. local dev + tests), the loader's
-// default behaviour (fetching the single `./build/clang.wasm`) is
-// untouched.
-let _chunkedWasm = null;
-async function fetchChunkedClangWasm(count, onProgress) {
-    if (_chunkedWasm) return _chunkedWasm;
-    const base = new URL('./build/', import.meta.url);
-    // Deployed chunks carry a content-hash in their filename
-    // (clang.wasm-{hash}.part-i) so a binary bump invalidates the
-    // browser's immutable HTTP cache automatically. Local dev (where
-    // CLANG_WASM_VERSION stays null) uses the unhashed names.
-    const filename = (i) =>
-        CLANG_WASM_VERSION
-            ? `clang.wasm-${CLANG_WASM_VERSION}.part-${i}`
-            : `clang.wasm.part-${i}`;
+// Cloudflare Pages rejects single files larger than 25 MiB at upload,
+// so the deploy ships `clang.wasm-{version}.zst` instead (~14 MiB on
+// the wire, 5.8× smaller than the original wasm). The `_headers` rule
+// sets `Content-Encoding: zstd` on that path — modern browsers
+// (Chrome 123+/Firefox 126+/Edge 123+) decompress at the network
+// layer for free; other browsers (Safari today) pass the raw zstd
+// bytes through, and we decompress in JS with `fzstd` (a 24 KB
+// pure-JS zstd decoder we vendor next to clang.js).
+//
+// We tell the two cases apart by looking at the first four bytes:
+//   - `\0asm` (00 61 73 6D) ⇒ wasm magic, the browser already
+//     decompressed; use the buffer directly.
+//   - `28 B5 2F FD`         ⇒ zstd magic, our turn to decompress.
+//
+// The decompressed buffer goes to Emscripten via `Module.wasmBinary`
+// which suppresses the default `clang.wasm` fetch.
+//
+// When the const is null (the committed default — i.e. local dev +
+// tests), Emscripten's default loader fetches the uncompressed
+// `./build/clang.wasm` sibling to clang.js, untouched.
 
-    // Aggregate byte counters so the demo can show overall download
-    // progress across the parallel chunk fetches. `totalBytes` only
-    // becomes reliable once every response header has landed; before
-    // then we send `0` so the UI can fall back to chunk-only progress.
-    const bytesPerChunk  = new Array(count).fill(0);
-    const totalPerChunk  = new Array(count).fill(0);
-    let chunksDone = 0;
+const WASM_MAGIC = [0x00, 0x61, 0x73, 0x6d];
+const ZSTD_MAGIC = [0x28, 0xb5, 0x2f, 0xfd];
+
+function magicMatch(buf, magic) {
+    if (buf.length < 4) return false;
+    for (let i = 0; i < 4; i++) if (buf[i] !== magic[i]) return false;
+    return true;
+}
+
+let _zstdDecompress = null;
+async function loadZstd() {
+    if (_zstdDecompress) return _zstdDecompress;
+    // stage-deploy copies node_modules/fzstd/esm/index.mjs to
+    // ./build/fzstd.mjs so this dynamic import resolves with no
+    // bundler step. Local dev (CLANG_WASM_VERSION=null) never reaches
+    // this path so a missing fzstd.mjs there is fine.
+    const m = await import('./build/fzstd.mjs');
+    _zstdDecompress = m.decompress;
+    return _zstdDecompress;
+}
+
+let _cachedClangWasm = null;
+async function fetchClangWasm(onProgress) {
+    if (_cachedClangWasm) return _cachedClangWasm;
+
+    // Kick off the fzstd loader in parallel with the download — even
+    // if we end up not needing it (native browser decoded the body),
+    // it's a ~24 KB no-op and the parallel work hides the import
+    // latency on browsers that DO need it.
+    const zstdPromise = loadZstd();
+
+    const url = new URL(
+        `./build/clang.wasm-${CLANG_WASM_VERSION}.zst`,
+        import.meta.url,
+    );
+    const r = await fetch(url);
+    if (!r.ok) {
+        throw new Error(`fetch ${url}: ${r.status} ${r.statusText}`);
+    }
+    const lenHeader = r.headers.get('Content-Length');
+    const totalBytes = lenHeader ? parseInt(lenHeader, 10) : 0;
+    let bytes = 0;
     let lastEmit = 0;
     const emit = (force) => {
         const now = performance.now();
-        // Throttle to ≈20 Hz so a fast LAN doesn't drown the UI thread
-        // in fetch-clang events. Always emit on chunk completion so
-        // the count-based progress line ticks promptly.
         if (!force && (now - lastEmit) < 50) return;
         lastEmit = now;
-        const bytes = bytesPerChunk.reduce((s, n) => s + n, 0);
-        const totalBytes = totalPerChunk.reduce((s, n) => s + n, 0);
-        onProgress?.({
-            stage: 'fetch-clang',
-            done: chunksDone,
-            total: count,
-            bytes,
-            totalBytes,
-        });
+        onProgress?.({ stage: 'fetch-clang', bytes, totalBytes });
     };
     emit(true);
-
-    const buffers = await Promise.all(
-        Array.from({ length: count }, async (_, i) => {
-            const url = new URL(filename(i), base);
-            const r = await fetch(url);
-            if (!r.ok) {
-                throw new Error(`fetch ${url}: ${r.status} ${r.statusText}`);
-            }
-            const lenHeader = r.headers.get('Content-Length');
-            totalPerChunk[i] = lenHeader ? parseInt(lenHeader, 10) : 0;
-            const reader = r.body.getReader();
-            const parts = [];
-            while (true) {
-                const { done, value } = await reader.read();
-                if (done) break;
-                parts.push(value);
-                bytesPerChunk[i] += value.byteLength;
-                emit(false);
-            }
-            const buf = new Uint8Array(bytesPerChunk[i]);
-            let off = 0;
-            for (const p of parts) { buf.set(p, off); off += p.byteLength; }
-            chunksDone += 1;
-            emit(true);
-            return buf;
-        }),
-    );
-
-    const total = buffers.reduce((s, b) => s + b.byteLength, 0);
-    const merged = new Uint8Array(total);
-    let offset = 0;
-    for (const b of buffers) {
-        merged.set(b, offset);
-        offset += b.byteLength;
+    const reader = r.body.getReader();
+    const parts = [];
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        parts.push(value);
+        bytes += value.byteLength;
+        emit(false);
     }
-    _chunkedWasm = merged.buffer;
-    return _chunkedWasm;
+    emit(true);
+    const merged = new Uint8Array(bytes);
+    let off = 0;
+    for (const p of parts) { merged.set(p, off); off += p.byteLength; }
+
+    if (magicMatch(merged, WASM_MAGIC)) {
+        // Browser handled the Content-Encoding: zstd already; merged
+        // is the raw wasm binary, ready to hand to Emscripten.
+        _cachedClangWasm = merged.buffer;
+        return _cachedClangWasm;
+    }
+    if (!magicMatch(merged, ZSTD_MAGIC)) {
+        throw new Error(
+            `clang.wasm bytes start with neither wasm nor zstd magic ` +
+            `(got ${[...merged.slice(0, 4)].map(b => b.toString(16).padStart(2, '0')).join(' ')})`,
+        );
+    }
+
+    // Browser didn't decode zstd for us — do it in JS. fzstd takes
+    // ~1 s on ~14 MiB → ~80 MiB on a recent laptop.
+    onProgress?.({ stage: 'decompress-clang' });
+    const decompress = await zstdPromise;
+    const decompressed = decompress(merged);
+    _cachedClangWasm = decompressed.slice().buffer;
+    return _cachedClangWasm;
 }
 
 async function clangModuleOpts(base, onProgress) {
-    if (CLANG_WASM_CHUNKS == null) return base;
-    const wasmBinary = await fetchChunkedClangWasm(CLANG_WASM_CHUNKS, onProgress);
+    if (CLANG_WASM_VERSION == null) return base;
+    const wasmBinary = await fetchClangWasm(onProgress);
     return { ...base, wasmBinary };
 }
 

--- a/llvm-mov/wasm/package-lock.json
+++ b/llvm-mov/wasm/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "llvm-mov-wasm",
       "version": "0.0.0",
+      "dependencies": {
+        "fzstd": "^0.1.1"
+      },
       "devDependencies": {
         "@playwright/test": "^1.55.0"
       }
@@ -41,6 +44,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.60.0",

--- a/llvm-mov/wasm/package.json
+++ b/llvm-mov/wasm/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0"
+  },
+  "dependencies": {
+    "fzstd": "^0.1.1"
   }
 }

--- a/llvm-mov/wasm/playwright.config.js
+++ b/llvm-mov/wasm/playwright.config.js
@@ -1,12 +1,24 @@
 import { defineConfig, devices } from '@playwright/test';
 
 // `E2E_BASE_URL` aims the spec at an already-running host (e.g. the
-// Cloudflare Pages preview). When unset, we serve the subproject root
-// over a local HTTP server — wasm module loaders use `fetch()` to grab
-// .wasm sibling files, and `file:` URLs are rejected by the browser's
-// fetch.
+// Cloudflare Pages preview). When unset, we serve locally — wasm
+// module loaders use `fetch()` to grab .wasm sibling files, and
+// `file:` URLs are rejected by the browser's fetch.
+//
+// Two local modes:
+//   - default: serve the subproject root (`llvm-mov/wasm/`) over
+//     `python -m http.server`. clang.wasm is uncompressed and lives
+//     next to clang.js — Emscripten's loader picks it up directly.
+//     wasm-config.js is unmodified, so the zstd path is dormant.
+//   - `E2E_SERVE_DIST=1`: serve the *staged deploy* under repo-root
+//     `dist/`. wasm-config.js has CLANG_WASM_VERSION set, the wrapper
+//     fetches `clang.wasm-{hash}.zst`, and the dist server applies
+//     `dist/_headers` (Content-Encoding: zstd, Content-Type:
+//     application/wasm) the same way CF Pages does. This exercises
+//     the production-shape loader against locally-served files.
 const REMOTE_BASE_URL = process.env.E2E_BASE_URL;
-const PORT = process.env.E2E_PORT || 8088;
+const SERVE_DIST = process.env.E2E_SERVE_DIST === '1';
+const PORT = process.env.E2E_PORT || (SERVE_DIST ? 8089 : 8088);
 
 export default defineConfig({
     testDir: './tests/e2e',
@@ -14,7 +26,8 @@ export default defineConfig({
     workers: 1,
     reporter: 'list',
     use: {
-        baseURL: REMOTE_BASE_URL || `http://127.0.0.1:${PORT}`,
+        baseURL: REMOTE_BASE_URL
+            || (SERVE_DIST ? `http://127.0.0.1:${PORT}/llvm-mov/` : `http://127.0.0.1:${PORT}`),
         // The wasm artifact is ~30+ MB; first instantiation in the test
         // browser can take several seconds. Remote runs add ~1 RTT on top.
         actionTimeout: 60_000,
@@ -25,7 +38,9 @@ export default defineConfig({
     // is the documented way to disable the auto-managed server.
     ...(REMOTE_BASE_URL ? {} : {
         webServer: {
-            command: `python3 -m http.server ${PORT} --bind 127.0.0.1`,
+            command: SERVE_DIST
+                ? `node tests/serve-dist.mjs`
+                : `python3 -m http.server ${PORT} --bind 127.0.0.1`,
             port: PORT,
             reuseExistingServer: !process.env.CI,
             stdout: 'pipe',

--- a/llvm-mov/wasm/scripts/build-wasm-clang.sh
+++ b/llvm-mov/wasm/scripts/build-wasm-clang.sh
@@ -134,26 +134,41 @@ if [ ! -f "$out/clang.wasm" ]; then
     exit 1
 fi
 
-# Split clang.wasm into ≤24 MiB chunks for the deploy. Cloudflare Pages
-# rejects single files larger than 25 MiB at upload time, and the demo
-# preview is the front-door for this subproject. The chunks live next
-# to the single file so local dev keeps using clang.wasm via the
-# Emscripten loader's default fetch; stage-deploy.sh decides whether
-# the static deploy should include the single file or the chunks.
+# Zstandard-compress clang.wasm for the deploy. clang.wasm itself is
+# ~80 MiB, well over Cloudflare Pages' 25 MiB/file upload cap.
+# `zstd -19 --long=23` brings it to ~16 MiB (5×) — fits in one file
+# and ~25 % smaller than gzip -9. The browser handles decompression
+# natively (`Content-Encoding: zstd` set in `_headers` at stage-deploy
+# time; Chrome 123+/Firefox 126+/Edge 123+ all ship it), so the
+# wrapper just fetches the .zst URL and feeds the bytes Emscripten
+# without touching any decompression library.
 #
-# `-d -a 1` numeric 1-digit suffix → clang.wasm.part-0..N (≤10 chunks).
-# clang.wasm is ~80 MiB → 4 chunks today. The wrapper enumerates by
-# `CLANG_WASM_CHUNKS` (the count), injected by stage-deploy.sh.
-rm -f "$out"/clang.wasm.part-*
-( cd "$out" && split -b 24M -d -a 1 clang.wasm clang.wasm.part- )
+# Window-size cap: `Content-Encoding: zstd` is governed by RFC 8878,
+# which lets clients reject frames with a window size > 8 MiB
+# (2^23). Chromium enforces that cap as a hard `net::ERR_ZSTD_
+# WINDOW_SIZE_TOO_BIG` — anything larger gets refused at the network
+# layer before our wrapper sees a single byte. `--long=23` pins the
+# encoder to that ceiling. Browsers without native zstd take the
+# fzstd JS path instead, which doesn't share the limit, but we still
+# encode for the strictest consumer so a single artefact serves both.
+#
+# The original .wasm stays in place for local dev (Emscripten's
+# default loader fetches the uncompressed clang.wasm next to clang.js
+# when the wrapper has no version pinned in wasm-config.js).
+#
+# (We used to ship `clang.wasm.part-{0..N}` chunks with a client-side
+# concat, then briefly used .gz; clean up either flavour so a fresh
+# build doesn't leave stale ones behind.)
+rm -f "$out"/clang.wasm.part-* "$out/clang.wasm.gz" "$out/clang.wasm.zst"
+zstd -19 --long=23 -f -o "$out/clang.wasm.zst" "$out/clang.wasm"
 
 # Content-hash of clang.wasm (first 12 hex of SHA-256). stage-deploy.sh
-# embeds this in the deployed chunk filenames so the URLs change on a
-# content bump — the browser's HTTP cache (with `Cache-Control:
-# immutable` set via `_headers`) then keeps the bytes forever between
-# page loads, and a real binary update naturally invalidates the
-# cache via the new URL. Local dev doesn't care about caching, so
-# this file is informational here.
+# embeds this in the deployed .zst filename so the URL changes on a
+# content bump — the browser's HTTP cache (`Cache-Control: immutable`
+# set via `_headers`) then keeps the bytes forever between page loads,
+# and a real binary update naturally invalidates the cache via the new
+# URL. Local dev doesn't care about caching, so this file is
+# informational here.
 sha256sum "$out/clang.wasm" | awk '{ print substr($1, 1, 12) }' > "$out/clang.wasm.hash"
 
 # Reuse the {"type":"module"} marker produced by the llvm-mov-llc
@@ -164,4 +179,4 @@ if [ ! -f "$out/package.json" ]; then
 fi
 
 echo "wasm clang build complete:"
-ls -la "$out"/clang.{js,wasm} "$out"/clang.wasm.part-*
+ls -la "$out"/clang.{js,wasm} "$out/clang.wasm.zst" "$out/clang.wasm.hash"

--- a/llvm-mov/wasm/scripts/stage-deploy.sh
+++ b/llvm-mov/wasm/scripts/stage-deploy.sh
@@ -10,28 +10,28 @@
 # the deploy lands at `dist/llvm-mov/` — the wasm/ segment is a build
 # detail, not something we want in the URL.
 #
-# clang.wasm chunk carve-out: at ~76 MiB it busts Cloudflare Pages'
-# 25 MiB per-file limit, so build-wasm-clang.sh splits it into
-# ≤24 MiB chunks (clang.wasm.part-0..N). We stage the chunks instead
-# of the single file and tell the wrapper how many there are via
-# CLANG_WASM_CHUNKS in wasm-config.js; llvm-mov.mjs then parallel-
-# fetches and concatenates them client-side and hands the bytes to
-# Emscripten via `Module.wasmBinary`. No external hosting, no CORS,
-# all same-origin.
+# clang.wasm zstd carve-out: at ~80 MiB the uncompressed wasm busts
+# Cloudflare Pages' 25 MiB/file limit, so the deploy ships
+# `clang.wasm-{hash}.zst` (~14 MiB) instead. The wrapper imports
+# `./build/fzstd.mjs` (a 24 KB pure-JS zstd decoder vendored from
+# the npm `fzstd` package) to decompress in-browser, side-stepping
+# the patchy native `Content-Encoding: zstd` support. The hash in
+# the filename means a binary bump rotates the URL and the immutable
+# cache (`Cache-Control: max-age=31536000, immutable`) flushes
+# naturally.
 #
 # Layout produced:
 #   dist/
-#     index.html                       (top-level landing page; refreshed
-#                                       only if dist/ doesn't already
-#                                       have one from a sibling deploy)
+#     index.html                            (top-level landing page)
+#     _headers                              (immutable cache for hashed artefacts)
 #     llvm-mov/
-#       index.html                     (demo)
-#       llvm-mov.mjs, llvm-mov.d.ts, wasm-config.js  (with CHUNKS injected)
+#       index.html                          (demo)
+#       llvm-mov.mjs, llvm-mov.d.ts, wasm-config.js
 #       build/llvm-mov-llc.{js,wasm}
-#       build/clang.js                 (the small Emscripten loader)
-#       build/clang.wasm.part-0..N     (chunks; client merges before init)
-#       build/package.json             ({"type":"module"} so the emcc ESM
-#                                       loader is parsed correctly)
+#       build/clang.js                      (small Emscripten loader)
+#       build/clang.wasm-{hash}.zst         (zstd-compressed clang.wasm)
+#       build/fzstd.mjs                     (single-file zstd decoder)
+#       build/package.json                  ({"type":"module"})
 
 set -euo pipefail
 
@@ -41,12 +41,15 @@ root="$(cd "$here/../.." && pwd)"
 dist="$root/dist"
 sub="$dist/llvm-mov"
 
+fzstd_src="$here/node_modules/fzstd/esm/index.mjs"
 required=(
     "$here/llvm-mov.mjs" "$here/llvm-mov.d.ts" "$here/index.html"
     "$here/wasm-config.js"
     "$here/build/llvm-mov-llc.js" "$here/build/llvm-mov-llc.wasm"
-    "$here/build/clang.js" "$here/build/clang.wasm.hash"
+    "$here/build/clang.js"
+    "$here/build/clang.wasm.zst" "$here/build/clang.wasm.hash"
     "$here/build/package.json"
+    "$fzstd_src"
 )
 for p in "${required[@]}"; do
     if [ ! -e "$p" ]; then
@@ -56,21 +59,8 @@ for p in "${required[@]}"; do
     fi
 done
 
-# Locate the clang.wasm chunks. build-wasm-clang.sh produces them
-# alongside the single file; if they're missing, fail before staging
-# (a partial deploy with no chunks would silently use the wasm-config
-# default and 404 on the client side).
-chunks=("$here"/build/clang.wasm.part-*)
-if [ ! -e "${chunks[0]}" ]; then
-    echo "missing: $here/build/clang.wasm.part-*" >&2
-    echo "run: make build-wasm-clang (which splits clang.wasm into chunks)" >&2
-    exit 1
-fi
-chunk_count=${#chunks[@]}
-
 # Wipe the previous staging so leftover artefacts from older runs
-# don't sneak into the deploy. CI checkouts are clean already; this
-# matters for local repro of the deploy contents.
+# (e.g. the old clang.wasm.part-* chunks) don't sneak into the deploy.
 rm -rf "$sub"
 mkdir -p "$sub/build"
 
@@ -91,10 +81,10 @@ cp "$here/build/llvm-mov-llc.js"   \
    "$sub/build/"
 
 # Read the content-hash build-wasm-clang.sh stamped on clang.wasm and
-# rename the chunks with it as we copy. The hashed filename lets us set
-# `Cache-Control: immutable` on the chunks via `_headers` below: the
-# browser keeps them forever, and a binary bump produces new URLs that
-# bypass the cached entries cleanly.
+# use it as the zst filename suffix. The wrapper composes the URL
+# using the same hash from wasm-config.js, the browser caches it
+# immutably, and a binary bump rotates the URL so a stale cache can't
+# pin the user to an old binary.
 hash="$(tr -d ' \n' < "$here/build/clang.wasm.hash")"
 case "$hash" in
     [0-9a-f]*) ;;
@@ -102,21 +92,19 @@ case "$hash" in
         echo "clang.wasm.hash content $hash is not a hex digest" >&2
         exit 1 ;;
 esac
-for chunk in "$here"/build/clang.wasm.part-*; do
-    base="$(basename "$chunk")"                       # clang.wasm.part-0
-    suffix="${base#clang.wasm.}"                      # part-0
-    cp "$chunk" "$sub/build/clang.wasm-${hash}.${suffix}"
-done
+cp "$here/build/clang.wasm.zst" "$sub/build/clang.wasm-${hash}.zst"
+# fzstd is the in-browser zstd decoder. The npm package's `esm/` build
+# is a single ~24 KB self-contained ES module — perfect to drop in
+# next to clang.js so the wrapper's `import('./build/fzstd.mjs')`
+# resolves with no bundler step.
+cp "$fzstd_src" "$sub/build/fzstd.mjs"
 
-# Tell the wrapper how many chunks to fetch, and at what hash, by
-# sed'ing the const values in the staged wasm-config.js. Source stays
-# at `null` so local dev keeps using the single clang.wasm.
-sed -i \
-    -e "s|^export const CLANG_WASM_CHUNKS = null;|export const CLANG_WASM_CHUNKS = $chunk_count;|" \
-    -e "s|^export const CLANG_WASM_VERSION = null;|export const CLANG_WASM_VERSION = '$hash';|" \
+# Tell the wrapper which version of clang.wasm to ask for by sed'ing
+# the const value in the staged wasm-config.js. Source stays at `null`
+# so local dev keeps using the uncompressed single clang.wasm.
+sed -i "s|^export const CLANG_WASM_VERSION = null;|export const CLANG_WASM_VERSION = '$hash';|" \
     "$sub/wasm-config.js"
-if ! grep -q "CLANG_WASM_CHUNKS = $chunk_count;" "$sub/wasm-config.js" \
-   || ! grep -q "CLANG_WASM_VERSION = '$hash';" "$sub/wasm-config.js"; then
+if ! grep -q "CLANG_WASM_VERSION = '$hash';" "$sub/wasm-config.js"; then
     echo "wasm-config.js placeholder substitution failed" >&2
     exit 1
 fi
@@ -125,17 +113,32 @@ fi
 # dist root. We're the first subproject to use it; if a sibling later
 # needs its own rules, refactor into an append-and-dedupe shape.
 #
-# CF Pages path matching only honours a single trailing `*`, so we
-# anchor on the `clang.wasm-` prefix (which is content-hashed by
-# stage-deploy and only appears on chunk files) and let the wildcard
-# cover both the hash and the `.part-N` tail. Content bumps rotate the
-# hash → new URL → fresh fetch, so caching this pattern as immutable
-# can't pin a user to a stale binary.
+# The pattern uses a single trailing `*` (CF Pages' matcher doesn't
+# honour mid-string wildcards) and anchors on the `clang.wasm-` prefix
+# that only the hashed zst appears under.
+#
+# `Content-Encoding: zstd` lights up the native-decompression fast
+# path on modern Chromium/Firefox/Edge. Browsers without native zstd
+# (Safari today) pass the raw bytes through to the JS layer, where
+# the wrapper's magic-byte check routes them to fzstd instead — see
+# `fetchClangWasm` in llvm-mov.mjs. The wrapper handles both shapes
+# without any UA sniffing.
+#
+# `Content-Type: application/wasm` is wrong for the on-wire bytes
+# (which are zstd) but right for what we hand Emscripten after
+# decompression. Browsers tolerate the mismatch on regular fetches;
+# the streaming wasm compile path doesn't run because we feed bytes
+# via `Module.wasmBinary` rather than letting Emscripten fetch.
+#
+# `Cache-Control: immutable` pairs with the hashed filename for free
+# cross-load caching.
 cat > "$dist/_headers" <<'EOF'
 /llvm-mov/build/clang.wasm-*
+  Content-Encoding: zstd
+  Content-Type: application/wasm
   Cache-Control: public, max-age=31536000, immutable
 EOF
 
 bytes=$(du -sb "$sub" | cut -f1)
 files=$(find "$sub" -type f | wc -l)
-echo "staged $files files ($chunk_count clang chunks @ $hash) / $(numfmt --to=iec --suffix=B "$bytes") into $sub"
+echo "staged $files files (clang.wasm.zst @ $hash) / $(numfmt --to=iec --suffix=B "$bytes") into $sub"

--- a/llvm-mov/wasm/tests/e2e/demo.spec.js
+++ b/llvm-mov/wasm/tests/e2e/demo.spec.js
@@ -89,6 +89,15 @@ for (const name of Object.keys(EXAMPLES)) {
         test(`demo compiles "${name}" at -O${opt} with byte-identical parity vs native`, async ({ page }) => {
             const pageErrors = [];
             page.on('pageerror', (e) => pageErrors.push(String(e)));
+            if (process.env.E2E_DEBUG) {
+                page.on('console', (msg) => console.log(`[console.${msg.type()}]`, msg.text()));
+                page.on('requestfailed', (req) => console.log(
+                    `[requestfailed] ${req.method()} ${req.url()} :: ${req.failure()?.errorText}`,
+                ));
+                page.on('response', (resp) => console.log(
+                    `[response] ${resp.status()} ${resp.url()}`,
+                ));
+            }
 
             // `index.html` (not `/`) so the path component of baseURL
             // is preserved. A leading slash would resolve against the

--- a/llvm-mov/wasm/tests/serve-dist.mjs
+++ b/llvm-mov/wasm/tests/serve-dist.mjs
@@ -1,0 +1,113 @@
+// Mini static server that mimics the bits of Cloudflare Pages our
+// deploy depends on:
+//   - Serves files from `../../dist/` (repo-root `dist/`).
+//   - Parses `dist/_headers` and applies the matching rules to each
+//     response, so `Content-Encoding: gzip` etc. land on the
+//     clang.wasm-{hash}.gz URL the same way they do in prod.
+//   - Sets correct MIME types for .wasm / .mjs / .js / .html so
+//     Emscripten's streaming compile and ES-module imports work.
+//
+// Used by `make test-e2e-dist` to drive demo.spec.js against the
+// staged deploy contents (with gzip) instead of the raw source tree.
+// CI runs both paths.
+
+import { createServer } from 'node:http';
+import { readFileSync, statSync, existsSync } from 'node:fs';
+import { join, extname, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+// tests/ → wasm/ → llvm-mov/ → repo root → dist/
+const distRoot = resolve(here, '..', '..', '..', 'dist');
+const port = parseInt(process.env.PORT || '8089', 10);
+
+const MIME = {
+    '.html': 'text/html; charset=utf-8',
+    '.js':   'application/javascript',
+    '.mjs':  'application/javascript',
+    '.wasm': 'application/wasm',
+    '.json': 'application/json',
+    '.gz':   'application/octet-stream', // overridden by _headers
+};
+
+// Parse the CF Pages `_headers` file. Each rule is a path pattern
+// followed by indented header lines until a blank line:
+//
+//   /llvm-mov/build/clang.wasm-*
+//     Content-Encoding: gzip
+//     Cache-Control: ...
+//
+// We mirror CF Pages' matching: a single trailing `*` matches any
+// suffix; otherwise the pattern is a literal match.
+function parseHeadersFile(path) {
+    if (!existsSync(path)) return [];
+    const text = readFileSync(path, 'utf8');
+    const rules = [];
+    let current = null;
+    for (const raw of text.split('\n')) {
+        const trimmedEnd = raw.replace(/\s+$/, '');
+        if (trimmedEnd === '') {
+            if (current) { rules.push(current); current = null; }
+            continue;
+        }
+        if (/^\s/.test(raw)) {
+            const m = trimmedEnd.match(/^\s+([^:]+):\s*(.*)$/);
+            if (m && current) current.headers[m[1].trim()] = m[2];
+        } else {
+            if (current) rules.push(current);
+            current = { pattern: trimmedEnd, headers: {} };
+        }
+    }
+    if (current) rules.push(current);
+    return rules;
+}
+
+function matchPattern(urlPath, pattern) {
+    if (pattern.endsWith('*')) {
+        return urlPath.startsWith(pattern.slice(0, -1));
+    }
+    return urlPath === pattern;
+}
+
+const headerRules = parseHeadersFile(join(distRoot, '_headers'));
+
+function resolvePath(urlPath) {
+    // Strip query / fragment, decode percent-escapes, refuse traversal.
+    const cleaned = decodeURIComponent(urlPath.split(/[?#]/)[0]);
+    if (cleaned.includes('..')) return null;
+    const fsPath = join(distRoot, cleaned);
+    if (!fsPath.startsWith(distRoot)) return null;
+    if (existsSync(fsPath) && statSync(fsPath).isDirectory()) {
+        return join(fsPath, 'index.html');
+    }
+    return fsPath;
+}
+
+createServer((req, res) => {
+    const fsPath = resolvePath(req.url || '/');
+    if (!fsPath || !existsSync(fsPath)) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('404 not found\n');
+        return;
+    }
+    const body = readFileSync(fsPath);
+    const headers = {};
+    const mime = MIME[extname(fsPath)];
+    if (mime) headers['Content-Type'] = mime;
+    // _headers rules win over the MIME default.
+    for (const rule of headerRules) {
+        if (matchPattern(req.url || '/', rule.pattern)) {
+            for (const [k, v] of Object.entries(rule.headers)) {
+                headers[k] = v;
+            }
+        }
+    }
+    // Node won't auto-set Content-Length when we pass a Buffer to .end,
+    // but the playwright test paths benefit from one being present (we
+    // use it in the wrapper to drive the download progress bar).
+    headers['Content-Length'] = String(body.byteLength);
+    res.writeHead(200, headers);
+    res.end(body);
+}).listen(port, '127.0.0.1', () => {
+    console.log(`serve-dist on http://127.0.0.1:${port}/ (root=${distRoot}, _headers rules=${headerRules.length})`);
+});

--- a/llvm-mov/wasm/wasm-config.js
+++ b/llvm-mov/wasm/wasm-config.js
@@ -1,17 +1,18 @@
 // Wasm artefact loading config.
 //
-// `clang.wasm` is too large (~76 MiB) for Cloudflare Pages' 25 MiB
-// per-file upload limit, so the deploy splits it into ≤24 MiB chunks
-// (`clang.wasm.part-0..N`) and the wrapper concatenates them client-
-// side. `CLANG_WASM_CHUNKS` is the chunk count and
-// `CLANG_WASM_VERSION` is a short content hash of clang.wasm;
-// stage-deploy.sh sets both before staging. The hash is woven into
-// the deployed chunk filenames (`clang.wasm-{hash}.part-i`) so the
-// URL changes on a binary bump while the unchanged URL stays in the
-// browser's HTTP cache forever (CF Pages `_headers` sets `Cache-
-// Control: immutable` for the chunk pattern).
+// clang.wasm is too large (~80 MiB) for Cloudflare Pages' 25 MiB
+// per-file upload limit. The deploy ships it zstd-compressed at
+// `./build/clang.wasm-{CLANG_WASM_VERSION}.zst` (~14 MiB on the wire).
+// CF Pages serves it with `Content-Encoding: zstd` (set in `_headers`);
+// modern browsers (Chrome 123+/Firefox 126+/Edge 123+) decompress
+// natively at the network layer, others (Safari today) pass the raw
+// zstd bytes through and the wrapper decompresses with the bundled
+// fzstd module. The wrapper picks between the two paths by inspecting
+// the magic bytes of the fetched body, so no UA sniffing.
+// The hash in the filename invalidates the immutable HTTP cache the
+// moment the binary content changes.
 //
 // `null` (the committed default) keeps the colocated
-// `./build/clang.wasm` behavior for local dev + tests.
-export const CLANG_WASM_CHUNKS = null;
+// `./build/clang.wasm` behavior for local dev + tests — Emscripten's
+// default loader picks up the uncompressed file next to clang.js.
 export const CLANG_WASM_VERSION = null;


### PR DESCRIPTION
## 概要

PR #15 で入れた chunks 方式から zstd 圧縮 + fzstd JS フォールバックに切り替える PR。

- **chunks 1/4 のままダウンロードが進行する** UX を解消（chunk カウンタ自体がなくなる）
- **モダンブラウザでは `Content-Encoding: zstd` を効かせて network 層で展開**、未対応ブラウザは fzstd で JS 展開（UA sniff なし、magic byte で振り分け）
- ハッシュ付き URL + `Cache-Control: immutable` で binary bump 時のみ再 fetch
- `make test-e2e-dist` で `_headers` を尊重するローカルサーバ経由で prod-shape を CI で常時 gating

## 実装

### 圧縮
- `build-wasm-clang.sh`: `zstd -19 --long=23` で 80 MiB → 13.3 MiB
- `--long=23` (8 MiB window) は RFC 8878 が許す上限。Chromium はそれを超えると `net::ERR_ZSTD_WINDOW_SIZE_TOO_BIG` で network 層で拒否するため、`Content-Encoding: zstd` を出す前提だとこのキャップが必須

### デプロイ
- `stage-deploy.sh`: `clang.wasm-{hash}.zst` を staging し、`node_modules/fzstd/esm/index.mjs` (24 KB) を `./build/fzstd.mjs` として同梱
- `_headers`:
  ```
  /llvm-mov/build/clang.wasm-*
    Content-Encoding: zstd
    Content-Type: application/wasm
    Cache-Control: public, max-age=31536000, immutable
  ```

### ランタイム
- `llvm-mov.mjs`: body を一度だけ読み、最初 4 byte の magic でルーティング
  - `\0asm` → ブラウザがすでに展開済み → そのまま `Module.wasmBinary`
  - `28 b5 2f fd` → JS 側で fzstd 展開
- byte-level の progress 表示は維持。fzstd ロードは fetch と並行
- メモリキャッシュ (`_cachedClangWasm`) で再 fetch なし。バージョンが上がれば URL のハッシュが変わって自然に invalidate

### テスト
- `tests/serve-dist.mjs` (新): `_headers` を解釈する Node 静的サーバ。`make test-e2e-dist` から起動
- `playwright.config.js`: `E2E_SERVE_DIST=1` で `dist/` を `http://127.0.0.1:8089/llvm-mov/` で配信
- `demo.spec.js`: `E2E_DEBUG=1` で console / requestfailed / response をキャプチャ。デフォルト OFF だが今回の `ERR_ZSTD_WINDOW_SIZE_TOO_BIG` を当てるのに必要だったので gated で残置
- CI: `llvm-mov-wasm.yaml` に `test-e2e-dist` を追加。`deploy.yaml` + `llvm-mov-wasm.yaml` のキャッシュを `.part-*` → `.zst` に更新

## 動作確認

- ローカル `E2E_SERVE_DIST=1 npx playwright test`: 6/6 PASS（3 examples × 2 opt levels）
- CF Pages preview デプロイ後、Playwright で再確認して URL を共有する

## Test plan
- [ ] CI: `llvm-mov-wasm` ジョブ（`make test` / `make test-e2e` / `make test-e2e-dist` 全通過）
- [ ] CF Pages preview デプロイ
- [ ] preview に対して `E2E_BASE_URL=<preview-url>/llvm-mov/ npx playwright test`
- [ ] 手動: デモページを開き、初回の compile で fetch → instantiate → compile のステージが進捗し、2 回目以降は instantiate からスタート

🤖 Generated with [Claude Code](https://claude.com/claude-code)