### PR TITLE
llvm-mov/wasm: CI gating for the fzstd fallback path

### DIFF
--- a/.github/workflows/llvm-mov-wasm.yaml
+++ b/.github/workflows/llvm-mov-wasm.yaml
@@ -154,3 +154,12 @@ jobs:
       # only ever fires under that codepath.
       - name: test-e2e-dist (staged deploy + Content-Encoding: zstd)
         run: make test-e2e-dist
+
+      # And once more with the server stripping Content-Encoding so
+      # the wrapper has to fall back to its bundled fzstd decoder.
+      # Playwright's Chromium handles zstd natively, so without this
+      # step the JS-decompression path is uncovered on CI and a
+      # regression there would only show up for Safari users in
+      # production.
+      - name: test-e2e-dist-fzstd (forced JS-side decompression)
+        run: make test-e2e-dist-fzstd

--- a/llvm-mov/wasm/Makefile
+++ b/llvm-mov/wasm/Makefile
@@ -10,7 +10,8 @@ BUILD_DIR     ?= build
 
 .PHONY: help setup build build-wasm-llvm build-wasm-clang \
         build-wasm-llvm-mov-llc build-native-llvm-mov-llc \
-        test test-e2e test-e2e-dist stage-deploy serve clean distclean
+        test test-e2e test-e2e-dist test-e2e-dist-fzstd \
+        stage-deploy serve clean distclean
 
 help:
 	@echo "Targets:"
@@ -25,6 +26,8 @@ help:
 	@echo "                              and diff the rendered .s against native (needs npm + browsers)"
 	@echo "  test-e2e-dist               same as test-e2e but against the staged ../../dist/ via a"
 	@echo "                              _headers-respecting Node server — exercises the zstd path"
+	@echo "  test-e2e-dist-fzstd         same as test-e2e-dist but the server drops Content-Encoding"
+	@echo "                              so the wrapper falls back to fzstd — covers non-zstd browsers"
 	@echo "  stage-deploy                stage ../../dist/llvm-mov/ for Cloudflare Pages"
 	@echo "  serve                       static-serve the demo on \$$PORT (default 8087)"
 	@echo "  clean                       remove $(BUILD_DIR)"
@@ -95,6 +98,23 @@ test-e2e-dist: stage-deploy
 	@if [ ! -d node_modules/@playwright ]; then npm install; fi
 	@npx playwright install chromium >/dev/null 2>&1 || true
 	E2E_SERVE_DIST=1 npx playwright test
+
+# Same as test-e2e-dist but the dist server drops `Content-Encoding:
+# zstd`, so the wrapper sees the raw zstd bytes and has to fall
+# through to its in-browser fzstd decoder. Without this target the
+# default Chromium that ships with Playwright handles zstd natively
+# at the network layer and the fzstd fallback path is never
+# exercised on CI — a regression in fzstd integration would only
+# surface for Safari users in production. The spec asserts a
+# `decompress clang` label appears in the timing breakdown when
+# `E2E_FZSTD_EXPECTED` is set, so a future change that breaks the
+# magic-byte router and accidentally takes the native path again is
+# caught here.
+test-e2e-dist-fzstd: stage-deploy
+	@if [ ! -d node_modules/@playwright ]; then npm install; fi
+	@npx playwright install chromium >/dev/null 2>&1 || true
+	E2E_SERVE_DIST=1 SERVE_DIST_STRIP_ENCODING=1 E2E_FZSTD_EXPECTED=1 \
+	    npx playwright test
 
 # Same shape as ../../movfuscator-wasm/scripts/stage-deploy.sh — copies
 # the browser-loadable artifacts + the demo index.html into

--- a/llvm-mov/wasm/tests/e2e/demo.spec.js
+++ b/llvm-mov/wasm/tests/e2e/demo.spec.js
@@ -126,6 +126,19 @@ for (const name of Object.keys(EXAMPLES)) {
             expect(ll).toBe(EXPECTED[name][opt].ll);
             expect(asm).toBe(EXPECTED[name][opt].s);
             expect(pageErrors).toEqual([]);
+
+            // When the run is supposed to exercise the in-browser fzstd
+            // fallback (the deploy server is stripping
+            // `Content-Encoding: zstd`), prove the wrapper actually
+            // took that path: it emits a `decompress-clang` stage
+            // event, which the demo renders as "decompress clang" in
+            // the timing breakdown below the status line. A
+            // byte-identical asm alone wouldn't catch a regression
+            // where the native-decode branch silently handled the
+            // raw zstd bytes.
+            if (process.env.E2E_FZSTD_EXPECTED) {
+                await expect(page.locator('#timing')).toContainText('decompress clang');
+            }
         });
     }
 }

--- a/llvm-mov/wasm/tests/serve-dist.mjs
+++ b/llvm-mov/wasm/tests/serve-dist.mjs
@@ -20,6 +20,14 @@ const here = dirname(fileURLToPath(import.meta.url));
 // tests/ → wasm/ → llvm-mov/ → repo root → dist/
 const distRoot = resolve(here, '..', '..', '..', 'dist');
 const port = parseInt(process.env.PORT || '8089', 10);
+// `SERVE_DIST_STRIP_ENCODING=1` drops `Content-Encoding` from every
+// applied _headers rule. We use it to fake a browser that lacks
+// native `Content-Encoding: zstd` support: the raw zstd bytes flow
+// through, and the wrapper's magic-byte check has to route them
+// through fzstd. Without this knob the production-shape E2E never
+// exercises the JS-decompression path on a CI runner whose Chromium
+// natively decodes zstd.
+const stripEncoding = process.env.SERVE_DIST_STRIP_ENCODING === '1';
 
 const MIME = {
     '.html': 'text/html; charset=utf-8',
@@ -98,6 +106,7 @@ createServer((req, res) => {
     for (const rule of headerRules) {
         if (matchPattern(req.url || '/', rule.pattern)) {
             for (const [k, v] of Object.entries(rule.headers)) {
+                if (stripEncoding && k.toLowerCase() === 'content-encoding') continue;
                 headers[k] = v;
             }
         }
@@ -109,5 +118,6 @@ createServer((req, res) => {
     res.writeHead(200, headers);
     res.end(body);
 }).listen(port, '127.0.0.1', () => {
-    console.log(`serve-dist on http://127.0.0.1:${port}/ (root=${distRoot}, _headers rules=${headerRules.length})`);
+    const enc = stripEncoding ? ', stripping Content-Encoding (fzstd path)' : '';
+    console.log(`serve-dist on http://127.0.0.1:${port}/ (root=${distRoot}, _headers rules=${headerRules.length}${enc})`);
 });


### PR DESCRIPTION
## 概要

PR #30 で zstd + fzstd フォールバックを入れたが、Playwright の Chromium は native zstd 対応なので CI で **fzstd 経路は実走していなかった**。 fzstd 側の regression は Safari ユーザが踏むまで発覚しない状態だった。これを CI で gating する。

## 実装

- `serve-dist.mjs`: `SERVE_DIST_STRIP_ENCODING=1` で `_headers` の `Content-Encoding` を落とすモードを追加。生 zstd バイトがそのまま流れ、wrapper の magic-byte router が fzstd 経路に振り分けることになる。
- `demo.spec.js`: `E2E_FZSTD_EXPECTED=1` のとき `#timing` に `decompress clang` ラベルが出ているか assert。バイト一致だけだと「magic byte 判定が壊れて native 側で生 zstd を喰わせてもたまたま動いた」みたいな regression を見逃す可能性があるので、経路そのものに対する陽性確認を入れている。
- `Makefile`: `test-e2e-dist-fzstd` ターゲットで両 env をセット。同じ port (8089) を使い、`test-e2e-dist` と sequential に走らせる（Playwright が webServer を毎回起動・終了する）。
- `llvm-mov-wasm.yaml`: `test-e2e-dist` の直後に新ステップを追加。

## TDD 確認

1. spec 変更だけ入れて run → `decompress clang` が出ないので fail（serve-dist が strip しないため）
2. `SERVE_DIST_STRIP_ENCODING` 対応を入れて run → 6/6 PASS、サーバログに `stripping Content-Encoding (fzstd path)` が出る

ローカルでの確認:
```
E2E_SERVE_DIST=1 SERVE_DIST_STRIP_ENCODING=1 E2E_FZSTD_EXPECTED=1 npx playwright test
  6 passed (39.3s)
E2E_SERVE_DIST=1 npx playwright test
  6 passed (37.5s)
```

## Test plan
- [ ] CI: `llvm-mov-wasm` ジョブで `test-e2e-dist-fzstd` ステップが緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)