### PR TITLE
explorer: llvm-mov pipeline で compile→Run を成立させる (linkOpts.static + runtime: 'none')

### DIFF
--- a/explorer/CLAUDE.md
+++ b/explorer/CLAUDE.md
@@ -141,22 +141,29 @@ what you compiled".
 
 ## Known limitations
 
-- **Compile → Run is blocked by dynamic linking today.** Both in-
-  browser pipelines (movfuscator-wasm and llvm-mov clang) go through
-  the shared binutils-wasm `ld` with
-  `-dynamic-linker /lib/ld-linux.so.2`, so the produced ELF is
-  **dynamically linked**. movie86 only loads **static** ELFs
-  (PT_INTERP / PT_DYNAMIC → `LoadError: DynamicLinkingUnsupported`
-  at `Vm::new`). The Movie86Panel surfaces this in a red banner
-  (`data-testid="load-error"`) so the user understands the gap
-  rather than staring at a disabled Run button. Issue #36 tracks
-  adding a `static: true` option to
-  `movfuscator-wasm/movfuscator.mjs`'s `link()`; once that lands the
-  compile output will load cleanly and this section becomes a
-  historical footnote.
-- Until then, the optional **Upload** button is the only way to run a
-  user-supplied static ELF in-tab. The compiled output still feeds
-  the inspection panes (IR / asm / ELF hex / disasm) cleanly.
+- **llvm-mov path compiles → runs end-to-end.** With the static-link
+  primitive from PR #39 (`link({ static: true, runtime: 'none' })`)
+  the explorer's llvm-mov pipeline now links its output through
+  `_start.o + <user>.o` (no movfuscator CRT, no PT_INTERP / PT_DYNAMIC)
+  and the freshly-compiled ELF auto-loads into the embedded movie86.
+  Click Run → the mov-only ABI exit at the end of `_start` raises
+  `Fault::Exit(eax)` and the status row shows the exit code. The
+  Movie86Panel's red banner only fires now for the movfuscator path
+  (see next bullet).
+- **movfuscator path still surfaces a load-error banner.** The
+  movfuscator pipeline keeps the historical dynamic / movfuscator-CRT
+  link recipe because flipping it to `runtime: 'movfuscator', static:
+  true` is *necessary* but not sufficient: movie86 then accepts the
+  ELF but trips on an `Unmapped(0x88049309)` inside `master_loop`'s
+  dispatch table — a separate movie86 runtime investigation that's
+  tracked independently. Until that lands, the explorer keeps the
+  movfuscator path dynamic and surfaces the
+  `DynamicLinkingUnsupported` banner so the user understands the gap
+  rather than staring at a fault label they can't act on. The
+  inspection panes (IR / asm / ELF hex / disasm) keep working
+  regardless.
+- The optional **Upload** button still works for either path — useful
+  for inspecting / running a static ELF the explorer didn't produce.
 
 ## Things future Claude shouldn't relearn
 

--- a/explorer/explorer.d.mts
+++ b/explorer/explorer.d.mts
@@ -13,7 +13,14 @@ export interface CompileWrappers {
         link(
             objs: Uint8Array | Uint8Array[] | Record<string, Uint8Array>,
             libs?: Record<string, Uint8Array> | undefined,
-            opts?: { name?: string; extraLibs?: string[]; searchPaths?: string[] },
+            opts?: {
+                name?: string;
+                static?: boolean;
+                runtime?: 'movfuscator' | 'none';
+                extraLibs?: string[];
+                searchPaths?: string[];
+                extraInputs?: Record<string, Uint8Array>;
+            },
         ): Promise<Uint8Array>;
     };
     llvmMov?: {
@@ -38,7 +45,19 @@ export interface CompileParams {
         optLevel?: '0' | '1' | '2' | '3' | 's' | 'z';
         clangFlags?: string[];
         headers?: Record<string, string>;
-        linkOpts?: { name?: string; extraLibs?: string[]; searchPaths?: string[] };
+        linkOpts?: {
+            name?: string;
+            /** Drops `-dynamic-linker`; adds `-static`. movie86 requires
+             *  this. Defaults to `true` on the llvm-mov path inside
+             *  explorer.mjs; caller can override either way. */
+            static?: boolean;
+            /** Which CRT objects the wrapper auto-wraps the inputs in.
+             *  `'movfuscator'` (default) or `'none'`. */
+            runtime?: 'movfuscator' | 'none';
+            extraLibs?: string[];
+            searchPaths?: string[];
+            extraInputs?: Record<string, Uint8Array>;
+        };
         onProgress?: (stage: string) => void;
     };
     wrappers?: CompileWrappers;

--- a/explorer/explorer.mjs
+++ b/explorer/explorer.mjs
@@ -22,6 +22,24 @@
 // page is served from `make serve` or the deployed
 // `dist/explorer/index.html` (sibling subprojects).
 //
+// Link mode per compiler:
+//
+//  - **movfuscator** uses the wrapper's default `runtime: 'movfuscator'`
+//    dynamic link (PT_INTERP / PT_DYNAMIC present). The output is
+//    *inspectable* in the explorer's panes but movie86 still rejects
+//    it at `Vm::new` with `DynamicLinkingUnsupported`; the Movie86
+//    panel surfaces that gap in a banner. Closing it depends on a
+//    separate movie86 runtime-fault investigation around master_loop's
+//    dispatch table — out of scope for this module.
+//  - **llvm-mov** links statically with `runtime: 'none'`, supplying
+//    its own `_start` (calls `main` then writes `eax` to the mov-only
+//    ABI exit address). That recipe mirrors
+//    `movie86/wasm/examples/sources/build-mandelbrot.sh`'s
+//    `build_llvm` function and yields a movie86-loadable ELF
+//    end-to-end. The `_start.s` source is assembled on-demand using
+//    the same `as.wasm` the C side already needs, so we don't ship a
+//    pre-built `.o` static asset.
+//
 // Tests dependency-inject the wrappers via `opts.wrappers` so the unit
 // suite can exercise the orchestration without paying the ~80 MB
 // clang.wasm load. Production calls leave `wrappers` undefined and the
@@ -34,6 +52,23 @@ export const COMPILERS = Object.freeze(['movfuscator', 'llvm-mov']);
 // force the override every time. Same default the llvm-mov/wasm tests
 // and demo use.
 const MOV_TRIPLE = 'mov-unknown-linux-gnu';
+
+// _start for the llvm-mov pipeline. Calls `main()` then writes EAX
+// (main's return value) to the mov-only ABI exit address. movie86's
+// `WasmHost::abi_call` decodes that as `CALL_EXIT` and raises
+// `Fault::Exit(code)`. Mirrors
+// `movie86/wasm/examples/sources/_start_llvm.s` byte-for-byte (modulo
+// whitespace) — keeping the canonical recipe in one place would mean
+// shipping the asm as a static asset, which the explorer doesn't need
+// since we already have `as.wasm` warm for the user object anyway.
+export const LLVM_MOV_START_S = `\
+.intel_syntax noprefix
+.section .text
+.globl _start
+_start:
+    call main
+    mov [0x1FFE00FE], eax
+`;
 
 /**
  * Compile C source through the selected mov-only toolchain.
@@ -113,10 +148,35 @@ export async function compileWithCompiler(params) {
 
     onProgress('link');
     const tl = performance.now();
-    const elf = await w.movfuscator.link(obj, undefined, {
-        name: 'explorer.o',
-        ...(opts.linkOpts ?? {}),
-    });
+    let elf;
+    if (compiler === 'llvm-mov') {
+        // llvm-mov pipeline: link statically with no movfuscator runtime,
+        // supplying our own `_start.o` that calls main() then exits via
+        // the mov-only ABI. movie86 loads the resulting ELF (no
+        // PT_INTERP / PT_DYNAMIC) and steps through to Exit(eax).
+        // Assemble `_start.s` lazily through the same `as.wasm` we
+        // already loaded for the user object.
+        const startObj = await w.movfuscator.assemble(LLVM_MOV_START_S);
+        const linkInputs = {
+            '_start.o': startObj,
+            'explorer.o': obj,
+        };
+        const userLinkOpts = opts.linkOpts ?? {};
+        elf = await w.movfuscator.link(linkInputs, undefined, {
+            static: true,
+            runtime: 'none',
+            ...userLinkOpts,
+        });
+    } else {
+        // movfuscator pipeline: dynamic link via the historical CRT
+        // recipe (`runtime: 'movfuscator'` default). movie86 can't load
+        // the output today (DynamicLinkingUnsupported) — that gap is
+        // surfaced in the Movie86Panel banner, not papered over here.
+        elf = await w.movfuscator.link(obj, undefined, {
+            name: 'explorer.o',
+            ...(opts.linkOpts ?? {}),
+        });
+    }
     timings.link = performance.now() - tl;
 
     timings.total = performance.now() - t0;

--- a/explorer/src/lib/compiler.ts
+++ b/explorer/src/lib/compiler.ts
@@ -21,8 +21,17 @@ export interface CompileParams {
         headers?: Record<string, string>;
         linkOpts?: {
             name?: string;
+            /** Link statically (drops `-dynamic-linker`, adds `-static`).
+             *  movie86 needs this; the explorer's llvm-mov path defaults to
+             *  `true` in explorer.mjs. movfuscator stays dynamic until the
+             *  movie86 master_loop dispatch-table fault is resolved. */
+            static?: boolean;
+            /** Which CRT objects the wrapper auto-wraps the inputs in.
+             *  `'none'` = caller supplies `_start.o` (llvm-mov default). */
+            runtime?: 'movfuscator' | 'none';
             extraLibs?: string[];
             searchPaths?: string[];
+            extraInputs?: Record<string, Uint8Array>;
         };
         onProgress?: (stage: string) => void;
     };

--- a/explorer/src/lib/wrappers.ts
+++ b/explorer/src/lib/wrappers.ts
@@ -20,7 +20,20 @@ export interface MovfuscatorWrapper {
     link(
         objs: Uint8Array | Uint8Array[] | Record<string, Uint8Array>,
         libs?: Record<string, Uint8Array>,
-        opts?: { name?: string; extraLibs?: string[]; searchPaths?: string[] },
+        opts?: {
+            name?: string;
+            /** Drop `-dynamic-linker`, add `-static`. Required for
+             *  movie86-loadable output. */
+            static?: boolean;
+            /** Which CRT objects the wrapper auto-wraps the inputs in.
+             *  `'movfuscator'` (default) is the historical
+             *  `crt0 ... crtf crtd softfloat32` recipe. `'none'` emits
+             *  only the user inputs (the llvm-mov pipeline shape). */
+            runtime?: 'movfuscator' | 'none';
+            extraLibs?: string[];
+            searchPaths?: string[];
+            extraInputs?: Record<string, Uint8Array>;
+        },
     ): Promise<Uint8Array>;
     compileToElf(
         source: string | Record<string, string>,

--- a/explorer/tests/e2e/staging.spec.ts
+++ b/explorer/tests/e2e/staging.spec.ts
@@ -46,7 +46,10 @@ test('staging movfuscator compile populates IR/asm/ELF panes but surfaces the dy
         timeout: 120_000,
     });
 
-    // Inspect path works.
+    // Inspect path works. The ELF hex dump lives inside the `binary`
+    // tab of the Output card (default tab is `asm`); click into it so
+    // the dump mounts.
+    await page.getByTestId('output-tab-binary').click();
     await expect(page.getByTestId('elf-hexdump')).toBeVisible({ timeout: 5_000 });
 
     // Run path is intentionally blocked today on the movfuscator side —

--- a/explorer/tests/e2e/staging.spec.ts
+++ b/explorer/tests/e2e/staging.spec.ts
@@ -1,13 +1,15 @@
 // Staging smoke — runs against the live Cloudflare Pages preview
 // deploy when `E2E_BASE_URL` is set. Validates the deployed bundle's
 // two-mode UX:
-//   1. Compile → inspect (IR / asm / ELF panes). The movie86 panel
-//      auto-loads and surfaces the dynamic-link gap as a banner
-//      (issue #36 will close the gap by adding `static: true` to
-//      movfuscator-wasm's `link()`; until then this is the expected
-//      shape).
+//   1. Compile → run (llvm-mov path). With the static-link primitive
+//      from PR #39 + the explorer wiring in this PR, llvm-mov's output
+//      loads into the embedded movie86 cleanly and Run reaches Exit(N).
+//      The movfuscator path stays dynamic for now — a separate movie86
+//      master_loop dispatch-table fault has to land before that side
+//      can also auto-run.
 //   2. Optional Upload escape hatch → run an arbitrary static ELF
-//      through movie86.
+//      through movie86. Still useful for ELFs the explorer didn't
+//      produce.
 
 import { expect, test } from '@playwright/test';
 
@@ -27,7 +29,7 @@ test('staging explorer loads and exposes the major UI surfaces', async ({ page }
     await expect(page.getByTestId('elf-upload')).toBeVisible();
 });
 
-test('staging movfuscator compile populates IR/asm/ELF panes but surfaces the static-link gap', async ({ page }) => {
+test('staging movfuscator compile populates IR/asm/ELF panes but surfaces the dynamic-link gap', async ({ page }) => {
     page.on('pageerror', (err) => console.log('[pageerror]', err.message));
 
     await page.goto('');
@@ -47,13 +49,54 @@ test('staging movfuscator compile populates IR/asm/ELF panes but surfaces the st
     // Inspect path works.
     await expect(page.getByTestId('elf-hexdump')).toBeVisible({ timeout: 5_000 });
 
-    // Run path is intentionally blocked today — the alert tells the
-    // user *why*. Closing #36 will make this assertion start failing
-    // and a Run-after-compile test should take its place.
+    // Run path is intentionally blocked today on the movfuscator side —
+    // the alert tells the user *why*. A separate movie86 master_loop
+    // dispatch-table fault has to land before this side can also
+    // auto-run. The llvm-mov compile→Run test below covers the happy
+    // path that PR #39 + this PR unlock.
     await expect(page.getByTestId('load-error')).toContainText(
         /DynamicLinkingUnsupported|dynamic/i,
         { timeout: 30_000 },
     );
+});
+
+test('staging llvm-mov compile auto-loads + Run reaches Exit(42)', async ({ page }) => {
+    page.on('pageerror', (err) => console.log('[pageerror]', err.message));
+
+    await page.goto('');
+
+    // llvm-mov is the App.tsx default, but pin it explicitly so the
+    // test is robust against the default flipping later.
+    await page.getByTestId('compiler-select').click();
+    await page.getByRole('option', { name: /llvm-mov/ }).click();
+
+    // The page's preset list already ships a "return 42" entry — same
+    // source the movfuscator inspection test uses above. Reusing it
+    // here keeps the two paths comparable.
+    await page.getByTestId('preset-select').click();
+    await page.getByRole('option', { name: /return 42/ }).click();
+
+    await page.getByTestId('compile-button').click();
+
+    await expect(page.getByTestId('status')).toContainText(/compiled in/, {
+        timeout: 180_000,
+    });
+
+    // The movie86 panel should NOT surface a load-error banner — the
+    // static-link + runtime: 'none' combination drops PT_INTERP /
+    // PT_DYNAMIC, so `Vm::new` accepts the freshly-compiled ELF.
+    await expect(page.getByTestId('load-error')).toHaveCount(0);
+
+    // Run becomes enabled once movie86 finishes the auto-load.
+    await expect(page.getByTestId('vm-run')).toBeEnabled({ timeout: 30_000 });
+    await page.getByTestId('vm-run').click();
+
+    // _start writes EAX (main's return value, 42) to the mov-only ABI
+    // exit address. WasmHost::abi_call decodes that as CALL_EXIT and
+    // raises Fault::Exit(42), which surfaces in the status row.
+    await expect(page.locator('text=Exit(42)').first()).toBeVisible({
+        timeout: 60_000,
+    });
 });
 
 test('staging Upload escape hatch runs a static ELF to Exit(42)', async ({ page }) => {

--- a/explorer/tests/unit.test.mjs
+++ b/explorer/tests/unit.test.mjs
@@ -47,6 +47,7 @@ test('compileWithCompiler uses injected wrappers (no real wasm load)', async () 
     const fakeIr = '; ModuleID = "in.c"\n';
     const fakeLlvmAsm = '/* llvm-mov asm */\n';
     const fakeObj = new Uint8Array([0x7f, 0x45, 0x4c, 0x46, 0x01]);
+    const fakeStartObj = new Uint8Array([0x7f, 0x45, 0x4c, 0x46, 0x02]);
     const fakeElf = new Uint8Array([0x7f, 0x45, 0x4c, 0x46, 0x01, 0x01]);
 
     const wrappers = {
@@ -57,10 +58,12 @@ test('compileWithCompiler uses injected wrappers (no real wasm load)', async () 
             },
             assemble: async (asm) => {
                 calls.push(['assemble', asm]);
-                return fakeObj;
+                // Distinguish the _start.s asm so the llvm-mov path
+                // assertions below can confirm it's the auto-staged one.
+                return asm.includes('_start:') ? fakeStartObj : fakeObj;
             },
-            link: async (obj, libs, opts) => {
-                calls.push(['link', obj.length, opts?.name]);
+            link: async (objs, libs, opts) => {
+                calls.push(['link', objs, opts]);
                 return fakeElf;
             },
         },
@@ -93,6 +96,12 @@ test('compileWithCompiler uses injected wrappers (no real wasm load)', async () 
         ['mov-compile', 'assemble', 'link'],
         'movfuscator order: compile → assemble → link',
     );
+    // movfuscator path keeps the historical dynamic / movfuscator-CRT
+    // recipe — the explorer doesn't force static here because the
+    // movie86 master_loop fault is a separate investigation.
+    const movLinkCall = calls.find(c => c[0] === 'link');
+    assert.notEqual(movLinkCall[2]?.static, true,
+        'movfuscator path should stay dynamic until the master_loop fault is fixed');
 
     calls.length = 0;
     const llvmRes = await compileWithCompiler({
@@ -105,10 +114,15 @@ test('compileWithCompiler uses injected wrappers (no real wasm load)', async () 
     assert.equal(llvmRes.ir, fakeIr, 'llvm-mov exposes the IR pane');
     assert.equal(llvmRes.asm, fakeLlvmAsm);
     assert.equal(llvmRes.elf, fakeElf);
+    // llvm-mov calls `assemble` twice: once for the user asm, once for
+    // the auto-staged `_start.s` that drives main() then hits the
+    // mov-only ABI exit address. Link then receives both objects in a
+    // Record so the basenames land in the ELF's .symtab in a
+    // predictable order.
     assert.deepEqual(
         calls.map(c => c[0]),
-        ['cToIR', 'llvm-compile', 'assemble', 'link'],
-        'llvm-mov order: cToIR → compile (IR→asm) → assemble → link',
+        ['cToIR', 'llvm-compile', 'assemble', 'assemble', 'link'],
+        'llvm-mov order: cToIR → compile → assemble user → assemble _start → link',
     );
     // Opt level + clang flags must reach the C-frontend; mtriple must
     // override the i386 triple clang stamps into the IR otherwise
@@ -121,4 +135,54 @@ test('compileWithCompiler uses injected wrappers (no real wasm load)', async () 
         irCompileCall[2].mtriple?.startsWith('mov-'),
         'IR → asm must force a mov-* triple, not the clang default',
     );
+    // The link call must be the movie86-compatible flavour:
+    //   - static (no PT_INTERP / PT_DYNAMIC)
+    //   - runtime: 'none' (caller-supplied _start, no movfuscator CRT)
+    //   - inputs are a Record so both _start.o and the user .o end up
+    //     in the link command, with _start.o first so ld -static
+    //     pulls main from the user .o left-to-right.
+    const llvmLinkCall = calls.find(c => c[0] === 'link');
+    const [, llvmLinkObjs, llvmLinkOpts] = llvmLinkCall;
+    assert.equal(llvmLinkOpts?.static, true, 'llvm-mov path must link statically');
+    assert.equal(llvmLinkOpts?.runtime, 'none',
+        'llvm-mov path must use runtime: none (caller supplies _start)');
+    assert.equal(typeof llvmLinkObjs, 'object');
+    assert.ok(!(llvmLinkObjs instanceof Uint8Array),
+        'llvm-mov link inputs must be a Record so both _start.o and explorer.o stage');
+    const objNames = Object.keys(llvmLinkObjs);
+    assert.deepEqual(objNames, ['_start.o', 'explorer.o'],
+        '_start.o must come before the user object so ld -static resolves main()');
+    assert.equal(llvmLinkObjs['_start.o'], fakeStartObj);
+    assert.equal(llvmLinkObjs['explorer.o'], fakeObj);
+});
+
+test('compileWithCompiler — caller linkOpts override the llvm-mov defaults', async () => {
+    // The explorer's own UI doesn't surface a Static toggle, but the
+    // public API still lets a caller flip back to dynamic / movfuscator
+    // runtime if they want to inspect that variant. Spread order in
+    // explorer.mjs puts caller opts last, so the override actually wins.
+    const calls = [];
+    const wrappers = {
+        movfuscator: {
+            assemble: async () => new Uint8Array([0x7f]),
+            link: async (objs, libs, opts) => {
+                calls.push({ objs, opts });
+                return new Uint8Array([0x7f, 0x45]);
+            },
+        },
+        llvmMov: {
+            cToIR: async () => 'ir',
+            compile: async () => 'asm',
+        },
+    };
+    const { compileWithCompiler } = await import('../explorer.mjs');
+    await compileWithCompiler({
+        compiler: 'llvm-mov',
+        source: 'int main(){return 0;}',
+        opts: { linkOpts: { static: false, runtime: 'movfuscator' } },
+        wrappers,
+    });
+    assert.equal(calls[0].opts.static, false, 'caller can opt back to dynamic');
+    assert.equal(calls[0].opts.runtime, 'movfuscator',
+        'caller can opt back to the movfuscator CRT');
 });


### PR DESCRIPTION
Depends on #39.

## Summary
- llvm-mov パスの最終 link を `{ static: true, runtime: 'none' }` に切り替え、`_start.s` (call main → `mov [0x1FFE00FE], eax` で mov-only ABI exit) を `as.wasm` でその場でアセンブルして `{ '_start.o', 'explorer.o' }` の Record として link に渡す。レシピは `movie86/wasm/examples/sources/build-mandelbrot.sh` の `build_llvm` と一致。
- これで movie86 が PT_INTERP / PT_DYNAMIC なし ELF を受理し、コンパイル直後の自動ロードが成功、Run で Exit(eax) に到達する (`Vm::loadElf` の `DynamicLinkingUnsupported` が立たなくなる)。
- movfuscator パスは従来通り dynamic / movfuscator runtime のまま。静的化しても movie86 が `master_loop` ディスパッチテーブルで `Unmapped(0x88049309)` を踏むため、別 issue として切り出して追跡する。`Movie86Panel` の red banner はこの片側だけで surface するようになる。
- `src/lib/{compiler,wrappers}.ts` + `explorer.d.mts`: link opts に `static` / `runtime` / `extraInputs` を追加 (PR #39 の wrapper シグネチャに合わせる)。
- `tests/unit.test.mjs`: llvm-mov パスが Record + `static: true` + `runtime: 'none'` で link を呼ぶこと、`_start.o` が user .o より前にいることを pin。caller の `linkOpts` で override 可能であることも検証。
- `tests/e2e/staging.spec.ts`: 「llvm-mov compile → 自動ロード → Run → Exit(42)」の E2E を追加。`E2E_BASE_URL` ありで preview に対して走る。
- `CLAUDE.md`: Known limitations を「llvm-mov 側は通る / movfuscator 側は別調査」に書き換え。

## Base branch
今は `movfuscator-wasm-static-link` (PR #39) を base にしている。#39 が `mov` にマージされたあと、こちらは `mov` に rebase する。

## Test plan
- [x] `node --test tests/unit.test.mjs` — 5/5 pass (新規 2 件含む)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — 893.84 kB JS / 287.62 kB gzip (前回 878 / 283 から +1.8% / +1.6%、目安の 2 MiB に十分収まる)
- [x] `npx playwright test tests/e2e/structure.spec.ts` — 4/4 pass
- [x] `npx playwright test tests/e2e/{staging,handover}.spec.ts` — `E2E_BASE_URL` 未設定でスキップが正しく出る
- [ ] `E2E_BASE_URL=<preview>` で `staging.spec.ts` の `staging llvm-mov compile auto-loads + Run reaches Exit(42)` が通ること (PR #39 マージ + デプロイ後にチェック)

## Notes
- `_start.s` をビルド済みオブジェクトとして `public/` に置く案も検討したが、explorer 起動時にはすでに `as.wasm` を user `.s` のために温めているので、その場でアセンブルする方が静的アセットを増やさず筋がいいと判断した。`movie86/wasm/examples/sources/_start_llvm.s` と内容は同じ (byte-for-byte) で、コメントもそこに揃えている。
- `_start.o` を `explorer.o` の前に並べるのは `ld -static` が左→右で archive を 1 度だけ scan するため。Record の iteration order は ES2015 以降の挿入順保証に依存している (#39 の wrapper も同じ前提で動く)。
- React 側 (`App.tsx`) には API 変更を入れていない。`onCompile` から渡る `opts.linkOpts` は将来の Static toggle UI が出てきたときの拡張点として残してある。