### PR TITLE
movie86: movfuscator runtime static-link order を regression-pin (bug は wrapper 側、emulator ではない)

### DIFF
--- a/movie86/DESIGN.md
+++ b/movie86/DESIGN.md
@@ -581,3 +581,69 @@ Diff output (span-based to handle a 10 MB `FlatMemory`):
 
 Designed for the wasm runtime: snapshot uses the `Memory` trait, not
 `FlatMemory` directly, so a future paged memory impl works too.
+
+## 2026-05-29 follow-up: movfuscator-runtime static-link order
+
+When statically linking a movfuscator-compiled user object alongside
+`crt0.o + crtf.o + crtd.o + softfloat32.o` plus a caller stub
+(`sigaction` / `exit`), **the stub object MUST be placed after
+`softfloat32.o`**, not between `crt0.o` and `crtf.o`. Putting it
+in the middle deterministically triggers
+`Fault::Unmapped(0x80000000 | dst)` partway through master_loop's
+first iteration.
+
+### Why
+
+`master_loop` is split across two objects:
+
+- `crt0.o.text` carries the head — 1406 bytes of mov-only setup +
+  dispatch table walking that ends with `mov (%eax),%eax`.
+- `crtf.o.text` carries the tail — 8 bytes: `mov esp, [&sesp]`
+  followed by `mov cs, ax` (the SIGILL re-entry trick).
+
+The linker concatenates `.text` sections in command-line order. For
+master_loop's straight-line fallthrough to work, nothing whose `.text`
+contains a control-flow boundary (`ret`, `jmp`, `call`) may sit between
+those two pieces. movfuscator user code is fine — it's all `mov` — and
+naturally tail-calls into `crtf.o`'s `mov cs, ax` epilogue. A
+hand-written assembly stub like
+```
+sigaction: movl $0, %eax ; ret
+exit:      movl 4(%esp), %ebx ; movl $1, %eax ; int $0x80
+```
+is NOT fine — its `c3 ret` byte appears in the linked text at exactly
+the spot master_loop's fallthrough crosses, and pops a value off the
+shadow stack (`esp = &data_p = 0x08686134` region) that master_loop
+staged for itself. The value is movfuscator's `MOV_OFFSET`-encoded
+label form (real address + `0x80000000`), so the resulting jump target
+has bit 31 set and `FlatMemory` correctly traps it as `Unmapped`.
+
+### How `movfuscator-wasm`'s `link({ static: true })` got this wrong
+
+The wrapper concatenates `crt0.o + <user objs> + crtf.o + crtd.o +
+softfloat32.o`. For *production* movfuscator usage that historical
+order was fine because dynamic linking against libc never injected
+non-mov `.text` between crt0 and crtf — `sigaction` / `exit` resolved
+to `.plt` stubs in a separate section. Once the wrapper started
+supporting static link via `{ static: true }` and callers started
+supplying caller stub objects in their user-objs list, that historical
+order became a foot-gun.
+
+The right shape for the static path is `crt0.o + <user objs that
+are mov-only> + crtf.o + crtd.o + softfloat32.o + <caller stubs
+with non-mov text>`. `movie86/scripts/link-real-return42.sh` does
+this; `movfuscator-wasm`'s wrapper needs to (issue tracked on PR
+#39's branch — the fix belongs there, not in movie86).
+
+### Pinned by
+
+`cli/tests/e2e.rs::movfuscator_runtime_link_order_pin` builds both
+layouts from the committed `return42.o` + a real
+`as`/`ld`-assembled stub and asserts:
+
+- broken layout → `Fault::Unmapped(addr)` with bit 31 set
+- working layout → `Exit(0)`
+
+Skipped when the vendor movfuscator runtime objects aren't materialized
+(env: `MOVIE86_MOVF_BUILD`, `MOVIE86_MOVF_SOFTFLOAT_DIR`; default paths
+follow `movfuscator-wasm/vendor/movfuscator/...`).

--- a/movie86/cli/tests/e2e.rs
+++ b/movie86/cli/tests/e2e.rs
@@ -418,6 +418,188 @@ fn handover_round_trip_via_dump_load_context_continues_to_exit() {
     let _ = std::fs::remove_file(&dump_path);
 }
 
+/// movfuscator-runtime link-order pin: when caller user/stub objects
+/// are placed between `crt0.o` and `crtf.o` on the `ld` command line,
+/// `master_loop`'s straight-line body is fragmented — its head lives
+/// in `crt0.o.text` (1406 bytes) and its tail (`mov esp, [&sesp]; mov
+/// cs, ax`) lives in `crtf.o.text` (8 bytes), and the linker
+/// concatenates the two adjacently *only* if nothing else's `.text`
+/// sits between them.
+///
+/// Drop a caller `stub.o` (`sigaction` / `exit`) between them and the
+/// `master_loop` fallthrough crosses the stub's body. The stub's
+/// `c3 ret` pops a value off the *shadow* stack that `master_loop`
+/// staged for itself — a movfuscator-encoded label `0x80000000 + dest`
+/// — and the CPU's `ret` jumps to that high-bit-set address.
+/// `FlatMemory` traps it as `Fault::Unmapped(addr)`.
+///
+/// This is **not** a movie86 emulation bug — the bit is set
+/// deliberately by `mov eax, 0x88049309` in `master_loop`'s body,
+/// which is movfuscator's `MOV_OFFSET` label encoding (real addr +
+/// `0x80000000`). movie86 preserves the value correctly through every
+/// move; the runtime would have stripped the high bit at a later
+/// stage if execution had stayed on the `master_loop` fallthrough
+/// path.
+///
+/// The fix lives on the link-recipe side: caller objects must be
+/// linked *after* `crtf.o crtd.o softfloat32.o`, not between `crt0.o`
+/// and `crtf.o`. `movie86/scripts/link-real-return42.sh` does this
+/// correctly; the `movfuscator-wasm` `link({ static: true })` wrapper
+/// does not (issue surfaced through PR #39's static-link branch).
+///
+/// This test pins both the failing layout (so a future fix to that
+/// wrapper still observes the same emulator-side fault as a hard
+/// signal) and the working layout (so a regression that breaks the
+/// working layout fails loudly here).
+///
+/// Skipped (returns silently) when the vendored movfuscator runtime
+/// objects aren't materialized. Materialize via:
+///   cd movfuscator-wasm && make setup && make build-native
+/// The test picks up the canonical paths automatically; override via
+/// `MOVIE86_MOVF_BUILD` and `MOVIE86_MOVF_SOFTFLOAT_DIR`.
+#[test]
+#[allow(clippy::too_many_lines, clippy::similar_names)]
+fn movfuscator_runtime_link_order_pin() {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    // Resolve where vendor objects live. Default to the canonical
+    // movfuscator-wasm layout one repo above this crate; allow override
+    // for git-worktree or CI shapes.
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir
+        .ancestors()
+        .nth(2)
+        .expect("repo root above cli/")
+        .to_path_buf();
+    let default_build = repo_root.join("movfuscator-wasm/vendor/movfuscator/build");
+    let default_softfloat = repo_root.join("movfuscator-wasm/vendor/movfuscator/movfuscator/lib");
+    let build_dir = std::env::var_os("MOVIE86_MOVF_BUILD").map_or(default_build, PathBuf::from);
+    let softfloat_dir =
+        std::env::var_os("MOVIE86_MOVF_SOFTFLOAT_DIR").map_or(default_softfloat, PathBuf::from);
+    let crt0 = build_dir.join("crt0.o");
+    let crtf = build_dir.join("crtf.o");
+    let crtd = build_dir.join("crtd.o");
+    let softfloat32 = softfloat_dir.join("softfloat32.o");
+    let return42_o = repo_root.join("movfuscator-wasm/tests/goldens-o/return42.o");
+    for f in [&crt0, &crtf, &crtd, &softfloat32, &return42_o] {
+        if !f.exists() {
+            eprintln!(
+                "movfuscator_runtime_link_order_pin: skipping — missing {}",
+                f.display()
+            );
+            eprintln!("  to enable: cd movfuscator-wasm && make setup && make build-native");
+            return;
+        }
+    }
+    // /usr/bin/as and /usr/bin/ld required.
+    if !std::path::Path::new("/usr/bin/as").exists()
+        || !std::path::Path::new("/usr/bin/ld").exists()
+    {
+        eprintln!(
+            "movfuscator_runtime_link_order_pin: skipping — /usr/bin/as or /usr/bin/ld missing"
+        );
+        return;
+    }
+
+    let tmp = std::env::temp_dir().join(format!("movie86-linkorder-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp).expect("create tmpdir");
+
+    // Caller-supplied stub matching PR #39's static-link test:
+    // sigaction returns 0; exit(status) issues int 0x80 SYS_exit. The
+    // cdecl `ret` inside `sigaction` is the load-bearing instruction
+    // for this test — it's the one that pops the master_loop-staged
+    // label when the stub object is inserted between crt0 and crtf.
+    let stub_s = tmp.join("stub.s");
+    std::fs::write(
+        &stub_s,
+        b".text\n\
+         .globl sigaction\n\
+         .type sigaction, @function\n\
+         sigaction:\n    \
+             movl $0, %eax\n    \
+             ret\n\
+         .globl exit\n\
+         .type exit, @function\n\
+         exit:\n    \
+             movl 4(%esp), %ebx\n    \
+             movl $1, %eax\n    \
+             int $0x80\n",
+    )
+    .expect("write stub.s");
+    let stub_o = tmp.join("stub.o");
+    let as_status = Command::new("/usr/bin/as")
+        .args(["--32", "-o"])
+        .arg(&stub_o)
+        .arg(&stub_s)
+        .status()
+        .expect("spawn /usr/bin/as");
+    assert!(as_status.success(), "as failed: {as_status}");
+
+    // Helper: invoke /usr/bin/ld with a given object order and run the
+    // result through `run_elf`. Returns the outcome.
+    let link_and_run = |out: &std::path::Path, order: &[&std::path::Path]| -> RunOutcome {
+        let mut cmd = Command::new("/usr/bin/ld");
+        cmd.args(["-m", "elf_i386", "-static", "--hash-style=gnu"]);
+        for o in order {
+            cmd.arg(o);
+        }
+        cmd.arg("-o").arg(out);
+        let status = cmd.status().expect("spawn /usr/bin/ld");
+        assert!(status.success(), "ld failed: {status}");
+        let bytes = std::fs::read(out).expect("read linked elf");
+        run_elf(&bytes)
+    };
+
+    // --- Broken layout: stub between user code and crtf ---
+    // This is the exact order PR #39's link({ static: true }) emits.
+    // master_loop's straight-line body falls through the stub's
+    // `sigaction: mov eax,0; ret` sequence; the ret pops the value
+    // master_loop staged on the shadow stack (a movfuscator-encoded
+    // label, high bit set), and the CPU jumps there.
+    let broken_out = tmp.join("return42-broken.elf");
+    let broken_outcome = link_and_run(
+        &broken_out,
+        &[&crt0, &return42_o, &stub_o, &crtf, &crtd, &softfloat32],
+    );
+    match broken_outcome {
+        RunOutcome::Fault(movie86::Fault::Unmapped(addr)) => {
+            // Bit 31 must be set — that's the movfuscator MOV_OFFSET
+            // encoding. The low 31 bits land somewhere inside the
+            // linked binary's text region (master_loop body).
+            assert!(
+                addr & 0x8000_0000 != 0,
+                "expected MOV_OFFSET-encoded label (bit 31 set), got {addr:#010x}"
+            );
+            let real = addr & 0x7fff_ffff;
+            assert!(
+                (0x0804_8000..=0x0904_8000).contains(&real),
+                "expected target near linked text (~0x08049...), got {addr:#010x}"
+            );
+        }
+        other => panic!("broken layout: expected Fault::Unmapped(MOV_OFFSET addr), got {other:?}"),
+    }
+
+    // --- Working layout: stub at the end, after the movfuscator
+    // runtime objects. master_loop's body stays contiguous. ---
+    let good_out = tmp.join("return42-good.elf");
+    let good_outcome = link_and_run(
+        &good_out,
+        &[&crt0, &return42_o, &crtf, &crtd, &softfloat32, &stub_o],
+    );
+    match good_outcome {
+        // movfuscator's crt0 hardcodes `push("$0"); jmp_extern("exit")`,
+        // so the int-0x80 SYS_exit stub terminates with status 0
+        // regardless of what `main` returned. See `link-real-return42.sh`
+        // for the same observation.
+        RunOutcome::Exit(0) => {}
+        other => panic!("working layout: expected Exit(0), got {other:?}"),
+    }
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
 #[test]
 fn fault_on_unsupported_syscall() {
     // mov eax, 999 ; int 0x80  → syscall 999 is unimplemented


### PR DESCRIPTION
## 根本原因

PR #39 の `link({ static: true })` wrapper は caller objects を `crt0.o` と `crtf.o` の間に置く:

```
crt0.o + <user .o + stubs .o> + crtf.o + crtd.o + softfloat32.o
```

`master_loop` の body は 2 つの object に分割されている:

- `crt0.o.text` — 1406 B の mov-only setup + dispatch table walking (head)
- `crtf.o.text` — 8 B: `mov esp, [&sesp]; mov cs, ax` (tail, SIGILL 再エントリ trick)

linker は `.text` セクションをコマンドライン順に連結する。master_loop の straight-line fallthrough は head の最後の命令と tail の最初の命令が隣接していることに依存している。movfuscator の user code は (全部 mov なので) 間に挟まっても無害だが、caller stub のような

```asm
sigaction: movl $0, %eax ; ret
exit:      movl 4(%esp), %ebx ; movl $1, %eax ; int $0x80
```

は `c3 ret` byte を持ち、それが master_loop の fallthrough 経路に落ちる。`ret` は shadow stack (`[esp=0x08686134]`) から値を pop するが、それは master_loop が次の dispatch のために stage していた `MOV_OFFSET | dest = 0x80000000 | dest = 0x88049309` というエンコード値である。CPU の `ret` はその bit-31-set アドレスにジャンプし、`FlatMemory` が正しく `Fault::Unmapped(0x88049309)` で拒否する。

**これは movie86 emulation のバグではない。** bit 31 は master_loop の body 内の `mov eax, 0x88049309` で意図的に立てられている (movfuscator の label エンコード); movie86 は全 mov で値をビット単位で保存する; intended fallthrough を走り続けていれば *runtime* は後段の master_loop stage で高 bit を strip していたはず。

## 真の修正箇所

`movfuscator-wasm` の `link({ static: true })` は caller objects を movfuscator runtime objects の **後ろ** に置くべき:

```
crt0.o + <mov-only user .o> + crtf.o + crtd.o + softfloat32.o + <non-mov caller stubs>
```

`movie86/scripts/link-real-return42.sh` は既にこの順序で書かれており、runnable ELF (`Exit(0)`) を生成する。follow-up は `movfuscator-wasm` 側で行う (→ PR #50)。

## この PR で movie86 に入れたもの

- `cli/tests/e2e.rs::movfuscator_runtime_link_order_pin` — 既存 `return42.o` + 実 `as` / `ld` でアセンブルした stub から両 layout をビルドし、以下を assert:
  - broken layout → `Fault::Unmapped(addr)` で bit 31 が set、low 31 bits が linked text 範囲内
  - working layout → `Exit(0)`

  vendored movfuscator runtime objects が materialize されていない時は silently skip。`MOVIE86_MOVF_BUILD` / `MOVIE86_MOVF_SOFTFLOAT_DIR` env で override 可能。

- `movie86/DESIGN.md` — "2026-05-29 follow-up: movfuscator-runtime static-link order" セクションを新設し、なぜ master_loop が分割されるのか・どんな foot-gun か・真の修正箇所がどこか、を文書化

## Test plan

- [x] `cargo test --workspace --all-targets` — 8 e2e + 58 core unit + handover 全 pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy --target wasm32-unknown-unknown -- -D warnings` clean
- [x] `node movie86/wasm/tests/smoke.mjs` — 12 smoke case 全 pass

## 関連

- **#39** (merged): static link option を追加した PR (broken layout を導入した側)
- **#50** (open): `movfuscator-wasm` 側で link 順序を `crt0 crtf crtd softfloat32 <caller>` に修正する follow-up
- **#45** (merged): explorer の compile→Run。`runtime: 'none'` を使うため今回のバグの影響を受けない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
