### PR TITLE
turbo86+wasm: MemUpdate Outbound — handover 中も async に memory 共有

### DIFF
--- a/movie86/cli/src/context_json.rs
+++ b/movie86/cli/src/context_json.rs
@@ -25,7 +25,7 @@ use base64::engine::general_purpose::STANDARD as B64_STANDARD;
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 
-use movie86::{Context, MemRegion, Regs};
+use movie86::{Context, MemRegion, Regs, Reservation};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct WireRegs {
@@ -107,6 +107,32 @@ impl From<WireRegion> for MemRegion {
 struct WireContext {
     regs: WireRegs,
     regions: Vec<WireRegion>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    reservations: Vec<WireReservation>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct WireReservation {
+    addr: u32,
+    size: u32,
+}
+
+impl From<&Reservation> for WireReservation {
+    fn from(r: &Reservation) -> Self {
+        WireReservation {
+            addr: r.addr,
+            size: r.size,
+        }
+    }
+}
+
+impl From<WireReservation> for Reservation {
+    fn from(w: WireReservation) -> Self {
+        Reservation {
+            addr: w.addr,
+            size: w.size,
+        }
+    }
 }
 
 mod b64_bytes {
@@ -135,6 +161,7 @@ pub fn to_json(ctx: &Context) -> Result<Vec<u8>, serde_json::Error> {
     let w = WireContext {
         regs: WireRegs::from(&ctx.regs),
         regions: ctx.regions.iter().map(WireRegion::from).collect(),
+        reservations: ctx.reservations.iter().map(WireReservation::from).collect(),
     };
     serde_json::to_vec(&w)
 }
@@ -150,6 +177,7 @@ pub fn to_json_pretty(ctx: &Context) -> Result<Vec<u8>, serde_json::Error> {
     let w = WireContext {
         regs: WireRegs::from(&ctx.regs),
         regions: ctx.regions.iter().map(WireRegion::from).collect(),
+        reservations: ctx.reservations.iter().map(WireReservation::from).collect(),
     };
     serde_json::to_vec_pretty(&w)
 }
@@ -165,6 +193,7 @@ pub fn from_json(bytes: &[u8]) -> Result<Context, serde_json::Error> {
     Ok(Context {
         regs: w.regs.into(),
         regions: w.regions.into_iter().map(MemRegion::from).collect(),
+        reservations: w.reservations.into_iter().map(Reservation::from).collect(),
     })
 }
 
@@ -196,6 +225,7 @@ mod tests {
                     bytes: vec![0xca, 0xfe],
                 },
             ],
+            reservations: vec![],
         }
     }
 
@@ -274,9 +304,48 @@ mod tests {
         let ctx = Context {
             regs: Regs::default(),
             regions: vec![],
+            reservations: vec![],
         };
         let bytes = to_json(&ctx).unwrap();
         let back = from_json(&bytes).unwrap();
         assert_eq!(back, ctx);
+    }
+
+    #[test]
+    fn reservations_round_trip_through_json() {
+        // Pin that reservations make it through encode/decode and are
+        // emitted only when non-empty. The canvas FB mmap_request case
+        // (one 64-page reservation at 0xA0000) is the motivating
+        // shape; this test does not depend on the actual address.
+        let ctx = Context {
+            regs: Regs::default(),
+            regions: vec![],
+            reservations: vec![Reservation {
+                addr: 0x000A_0000,
+                size: 64 * 0x1000,
+            }],
+        };
+        let bytes = to_json(&ctx).unwrap();
+        let actual: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            actual["reservations"],
+            serde_json::json!([{ "addr": 655_360, "size": 262_144 }]),
+            "reservations field shape must match turbo86's Go-side JSON byte-for-byte",
+        );
+        let back = from_json(&bytes).unwrap();
+        assert_eq!(back, ctx);
+    }
+
+    #[test]
+    fn empty_reservations_omitted_from_json_for_backwards_compat() {
+        // Older receivers don't know the field exists; ensure we don't
+        // emit `"reservations": []` for snapshots that don't use it.
+        let ctx = sample_context();
+        let bytes = to_json(&ctx).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(
+            v.get("reservations").is_none(),
+            "empty reservations should be omitted, got: {v}",
+        );
     }
 }

--- a/movie86/cli/src/handover.rs
+++ b/movie86/cli/src/handover.rs
@@ -12,7 +12,7 @@
 //! use movie86::{Context, Regs};
 //!
 //! let mut client = HandoverClient::connect("ws://127.0.0.1:1234").unwrap();
-//! let ctx = Context { regs: Regs::default(), regions: vec![] };
+//! let ctx = Context { regs: Regs::default(), regions: vec![], reservations: vec![] };
 //! client.send(&Inbound::LoadContext { context: ctx, mode: Mode::Host }).unwrap();
 //! while let Ok(Some(ev)) = client.recv() {
 //!     match ev {
@@ -243,6 +243,7 @@ mod tests {
                 addr: 0x1000,
                 bytes: vec![0xcd, 0x80],
             }],
+            reservations: vec![],
         };
         client
             .send(&Inbound::LoadContext {
@@ -271,6 +272,7 @@ mod tests {
                 context: Context {
                     regs: Regs::default(),
                     regions: vec![],
+                    reservations: vec![],
                 },
                 mode: Mode::Host,
             })
@@ -304,6 +306,7 @@ mod tests {
                 context: Context {
                     regs: Regs::default(),
                     regions: vec![],
+                    reservations: vec![],
                 },
                 mode: Mode::Host,
             })

--- a/movie86/cli/src/lib.rs
+++ b/movie86/cli/src/lib.rs
@@ -841,6 +841,7 @@ fn write_context_at_step(
     let ctx = movie86::Context {
         regs: movie86::Regs::from_cpu(cpu),
         regions,
+        reservations: Vec::new(),
     };
     let bytes = match context_json::to_json_pretty(&ctx) {
         Ok(b) => b,

--- a/movie86/cli/src/tests.rs
+++ b/movie86/cli/src/tests.rs
@@ -273,6 +273,7 @@ fn apply_context_zeros_extent_before_overlaying_regions() {
             ..Default::default()
         },
         regions: Vec::new(),
+        reservations: Vec::new(),
     };
     apply_context_to_fresh_extent(&ctx, &mut cpu, &mut mem).unwrap();
     assert_eq!(
@@ -302,6 +303,7 @@ fn apply_context_overlays_regions_after_zeroing() {
             addr: 0x1100,
             bytes: vec![0xaa, 0xbb, 0xcc, 0xdd],
         }],
+        reservations: Vec::new(),
     };
     apply_context_to_fresh_extent(&ctx, &mut cpu, &mut mem).unwrap();
     assert_eq!(mem.read_u32(0x1100).unwrap(), 0xddcc_bbaa);
@@ -329,6 +331,7 @@ fn apply_context_drains_pending_log_writes_so_setup_does_not_taint_step_zero() {
             addr: 0x1100,
             bytes: vec![0xff; 8],
         }],
+        reservations: Vec::new(),
     };
     apply_context_to_fresh_extent(&ctx, &mut cpu, &mut mem).unwrap();
     assert!(

--- a/movie86/cli/src/turbo86_wire.rs
+++ b/movie86/cli/src/turbo86_wire.rs
@@ -19,7 +19,7 @@ use base64::engine::general_purpose::STANDARD as B64_STANDARD;
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 
-use movie86::{Context, MemRegion, Regs};
+use movie86::{Context, MemRegion, Regs, Reservation};
 
 /// Mirrors `proto.Mode`. Empty = default host on the Go side; we
 /// always emit explicit values to avoid implicit drift.
@@ -146,6 +146,32 @@ impl From<WireRegion> for MemRegion {
 struct WireContext {
     regs: WireRegs,
     regions: Vec<WireRegion>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    reservations: Vec<WireReservation>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct WireReservation {
+    addr: u32,
+    size: u32,
+}
+
+impl From<&Reservation> for WireReservation {
+    fn from(r: &Reservation) -> Self {
+        Self {
+            addr: r.addr,
+            size: r.size,
+        }
+    }
+}
+
+impl From<WireReservation> for Reservation {
+    fn from(w: WireReservation) -> Self {
+        Self {
+            addr: w.addr,
+            size: w.size,
+        }
+    }
 }
 
 impl From<&Context> for WireContext {
@@ -153,6 +179,7 @@ impl From<&Context> for WireContext {
         Self {
             regs: WireRegs::from(&c.regs),
             regions: c.regions.iter().map(WireRegion::from).collect(),
+            reservations: c.reservations.iter().map(WireReservation::from).collect(),
         }
     }
 }
@@ -162,6 +189,7 @@ impl From<WireContext> for Context {
         Self {
             regs: w.regs.into(),
             regions: w.regions.into_iter().map(MemRegion::from).collect(),
+            reservations: w.reservations.into_iter().map(Reservation::from).collect(),
         }
     }
 }
@@ -321,6 +349,7 @@ mod tests {
                         bytes: vec![0xca, 0xfe],
                     },
                 ],
+                reservations: vec![],
             },
             mode: Mode::Host,
         };

--- a/movie86/cli/tests/handover_turbo86.rs
+++ b/movie86/cli/tests/handover_turbo86.rs
@@ -140,6 +140,7 @@ fn handover_load_context_exit_round_trip_through_real_turbo86() {
             addr: ENTRY,
             bytes: vec![0xcd, 0x80], // int 0x80
         }],
+        reservations: vec![],
     };
 
     let mut client = HandoverClient::connect(&url).expect("connect turbo86");

--- a/movie86/core/src/context.rs
+++ b/movie86/core/src/context.rs
@@ -45,6 +45,21 @@ pub struct MemRegion {
     pub bytes: Vec<u8>,
 }
 
+/// An address range the receiver must map before resuming, even when
+/// the snapshot carries no bytes for it. Mirrors turbo86's
+/// `proto.Reservation`. The motivating case is the mov-only ABI
+/// `mmap_request` side effect: the sender executed the request, the
+/// resulting page is still all-zero, so `capture_sparse_regions`
+/// skipped it — but the next guest write expects the page to be
+/// mapped. Receivers with a fixed [`FlatMemory`] (movie86 core)
+/// treat reservations as a no-op; receivers that mmap dynamically
+/// (turbo86) replay them at load time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Reservation {
+    pub addr: u32,
+    pub size: u32,
+}
+
 /// Canonical i386 register set for migration.
 ///
 /// Field order matches turbo86's `proto.Regs` so a JSON encoder can
@@ -105,11 +120,14 @@ pub const SPARSE_PAGE_SIZE: u32 = 4096;
 
 /// A transferable guest-state snapshot. Receivers apply [`Context::regions`]
 /// to memory first, then load [`Context::regs`] into the CPU, then continue
-/// execution.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// execution. [`Context::reservations`] declares additional ranges that
+/// need to be mapped on the receiver but carry no bytes (e.g. an ABI
+/// `mmap_request` whose page was still zero at snapshot time).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Context {
     pub regs: Regs,
     pub regions: Vec<MemRegion>,
+    pub reservations: Vec<Reservation>,
 }
 
 /// Walk `mem` from `base` to `base + len` page by page, emitting only
@@ -292,6 +310,7 @@ mod tests {
         let ctx = Context {
             regs: Regs::from_cpu(&cpu),
             regions: capture_sparse_regions(&mem, 0x1000, 0x4000).unwrap(),
+            reservations: Vec::new(),
         };
 
         // Load into a fresh CPU + zero memory of the same extent.

--- a/movie86/core/src/lib.rs
+++ b/movie86/core/src/lib.rs
@@ -18,7 +18,7 @@ pub use abi_host::{
     CALL_MMAP_REQUEST, CALL_SET_VIDEO_MODE, CALL_WRITE,
 };
 pub use bios_host::{BiosArgs, BiosHost, BiosResult};
-pub use context::{capture_sparse_regions, load_context, Context, MemRegion, Regs};
+pub use context::{capture_sparse_regions, load_context, Context, MemRegion, Regs, Reservation};
 pub use cpu::{Cpu, Signal};
 pub use decode::decode;
 pub use elf::{ElfError, LoadSegment, LoadedElf};

--- a/movie86/wasm/index.html
+++ b/movie86/wasm/index.html
@@ -1243,12 +1243,13 @@ async function doSendToTurbo86() {
                 break;
             case 'video_mode':
                 // turbo86 surfaced a mov-only ABI set_video_mode write.
-                // movie86.mjs's `FRAMEBUFFER_MODES` lookup uses
-                // `vm.activeVideoMode`; writing the mode byte into the
-                // local Vm's ABI page (via vm.writeMem at the same
-                // address turbo86 caught) flips that getter so the
-                // canvas pane starts polling the right FB region.
-                state.vm.writeMem(0x1FFE_0010, new Uint8Array([msg.mode & 0xff]));
+                // `vm.activeVideoMode` is what `renderCanvases()` keys
+                // on to pick the active FB region. Use the dedicated
+                // setter — writeMem(0x1FFE_0010, ...) would silently
+                // no-op because the ABI page is intercepted by the CPU
+                // at dispatch time and isn't part of FlatMemory, so
+                // host-side writes there fall outside the mapped range.
+                state.vm.setActiveVideoMode(msg.mode & 0xff);
                 break;
             case 'mem_update': {
                 // Periodic in-flight memory snapshot from turbo86.

--- a/movie86/wasm/index.html
+++ b/movie86/wasm/index.html
@@ -1157,9 +1157,17 @@ async function doSendToTurbo86() {
     ws.onopen = () => {
         setT86Status('connected — sending Context', 'ok');
         try {
-            const frame = makeLoadContextMessage(ctx, mode);
+            // Ask turbo86 for periodic memory snapshots so the canvas
+            // pane keeps up with the in-flight guest. Read the cadence
+            // from the existing `refresh` knob — it's already "how
+            // often does the UI redraw" so reusing it is symmetrical
+            // with the local Run loop. Clamp ≥ 25 ms; a 0 turns
+            // progressive display off entirely.
+            const memUpdateMs = Math.max(0, Math.floor(Number($('refresh').value) || 100));
+            const frame = makeLoadContextMessage(ctx, mode, memUpdateMs);
             ws.send(frame);
-            appendT86Event('sent', `LoadContext (${frame.length.toLocaleString()} B JSON)`);
+            appendT86Event('sent',
+                `LoadContext (${frame.length.toLocaleString()} B JSON, mem_update=${memUpdateMs}ms)`);
             setT86Status('running…', 'ok');
             $('turbo86-pause').hidden = false;
             // Periodic full render so the meta cards (sourced from
@@ -1233,6 +1241,31 @@ async function doSendToTurbo86() {
                 turbo86.lastPaused = msg;
                 $('turbo86-restore').hidden = false;
                 break;
+            case 'video_mode':
+                // turbo86 surfaced a mov-only ABI set_video_mode write.
+                // movie86.mjs's `FRAMEBUFFER_MODES` lookup uses
+                // `vm.activeVideoMode`; writing the mode byte into the
+                // local Vm's ABI page (via vm.writeMem at the same
+                // address turbo86 caught) flips that getter so the
+                // canvas pane starts polling the right FB region.
+                state.vm.writeMem(0x1FFE_0010, new Uint8Array([msg.mode & 0xff]));
+                break;
+            case 'mem_update': {
+                // Periodic in-flight memory snapshot from turbo86.
+                // Apply every region to the local Vm so the canvas /
+                // memory panes show in-progress decoder output. Out-of-
+                // range bytes are silently skipped by writeMem, so
+                // turbo86's stack region (which the local Vm doesn't
+                // map) is harmless. JSON parse + base64 decode of the
+                // regions dominate the cost; 100 ms cadence is fine
+                // even for FHD-class snapshots.
+                let applied = 0;
+                for (const r of msg.regions) {
+                    applied += state.vm.writeMem(r.addr, r.bytes);
+                }
+                turbo86.stats.lastMemUpdateBytes = applied;
+                break;
+            }
         }
         renderT86Stats();
         // Follow toggle drives the in-handover render cadence the

--- a/movie86/wasm/movie86.mjs
+++ b/movie86/wasm/movie86.mjs
@@ -179,7 +179,19 @@ export function snapshotContext(vm) {
                 bytes: s.regionBytesAt(i),
             });
         }
-        return { regs, regions };
+        // Reservations: address ranges the guest mmap_request'd that
+        // carry no bytes (the page may still be all-zero). turbo86
+        // mmaps each one at LoadContext so the next guest write
+        // doesn't SIGSEGV on an unmapped page.
+        const reservations = [];
+        const m = s.reservationCount;
+        for (let i = 0; i < m; i++) {
+            reservations.push({
+                addr: s.reservationAddrAt(i),
+                size: s.reservationSizeAt(i),
+            });
+        }
+        return { regs, regions, reservations };
     } finally {
         s.free();
     }
@@ -250,6 +262,15 @@ export function makeLoadContextMessage(ctx, mode = 'host', memUpdateIntervalMs =
         },
         mode,
     };
+    // Reservations are optional; emit only when non-empty so the wire
+    // shape stays byte-for-byte with Go's `omitempty` on the Reservations
+    // field for snapshots that don't use it.
+    if (ctx.reservations && ctx.reservations.length > 0) {
+        msg.context.reservations = ctx.reservations.map(r => ({
+            addr: r.addr,
+            size: r.size,
+        }));
+    }
     if (memUpdateIntervalMs > 0) {
         msg.mem_update_interval_ms = memUpdateIntervalMs;
     }

--- a/movie86/wasm/movie86.mjs
+++ b/movie86/wasm/movie86.mjs
@@ -228,12 +228,18 @@ function base64ToBytes(b64) {
  * the guest depends on the same software signal model movie86 uses
  * (movfuscator-style `mov cs, ax` → SIGILL dispatch).
  *
+ * `memUpdateIntervalMs` (default 0 = disabled) asks turbo86 to emit
+ * `MemUpdate` Outbound events at the given cadence — progressive
+ * display works by applying those updates to the local Vm so the
+ * canvas pane keeps up with the in-flight guest.
+ *
  * @param {{regs: object, regions: Array<{addr: number, bytes: Uint8Array}>}} ctx
  * @param {'host'|'trap'} [mode='host']
+ * @param {number} [memUpdateIntervalMs=0]
  * @returns {string} JSON-encoded frame, ready for WebSocket.send().
  */
-export function makeLoadContextMessage(ctx, mode = 'host') {
-    return JSON.stringify({
+export function makeLoadContextMessage(ctx, mode = 'host', memUpdateIntervalMs = 0) {
+    const msg = {
         type: 'load_context',
         context: {
             regs: ctx.regs,
@@ -243,7 +249,11 @@ export function makeLoadContextMessage(ctx, mode = 'host') {
             })),
         },
         mode,
-    });
+    };
+    if (memUpdateIntervalMs > 0) {
+        msg.mem_update_interval_ms = memUpdateIntervalMs;
+    }
+    return JSON.stringify(msg);
 }
 
 /**
@@ -324,6 +334,19 @@ export function parseOutboundMessage(data) {
                 bytes: base64ToBytes(r.bytes),
             }));
             return { type: 'paused', regs: m.regs, regions, signal: m.signal, reason: m.reason };
+        }
+        case 'video_mode': return { type: 'video_mode', mode: m.mode };
+        case 'mem_update': {
+            // Periodic mid-session snapshot — same shape as paused.regions
+            // but no regs/signal/reason. Frontend applies the regions to
+            // its local Vm via `vm.writeMem`, so the canvas pane keeps
+            // up with the in-flight guest without waiting for terminal
+            // Paused / Exit.
+            const regions = (m.regions ?? []).map(r => ({
+                addr: r.addr,
+                bytes: base64ToBytes(r.bytes),
+            }));
+            return { type: 'mem_update', regions };
         }
         default:
             throw new Error(`unknown turbo86 outbound type ${JSON.stringify(m.type)}`);

--- a/movie86/wasm/src/lib.rs
+++ b/movie86/wasm/src/lib.rs
@@ -11,7 +11,7 @@
 use std::collections::BTreeMap;
 
 use movie86::bios_host::{BiosArgs, BiosHost, BiosResult};
-use movie86::context::{capture_sparse_regions, Regs as CoreRegs};
+use movie86::context::{capture_sparse_regions, Regs as CoreRegs, Reservation};
 use movie86::decode::decode as decode_insn;
 use movie86::elf::{flatten_with_stack, parse, LoadedElf};
 use movie86::libc_host::{LibcCall, LibcHost, LibcResult};
@@ -42,6 +42,16 @@ struct WasmHost {
     /// `None` until the guest sets a mode (so the demo UI knows to
     /// show "no mode selected" rather than picking a default canvas).
     active_video_mode: Option<u8>,
+    /// Address ranges the guest requested via the mov-only ABI
+    /// `mmap_request` call. In wasm these are no-ops at the time of
+    /// call (canvas demos pre-declare the FB as PT_LOAD, so the page
+    /// is already mapped), but we record them so `snapshotContext`
+    /// can hand them to the next engine as Reservations. Without
+    /// this, a snapshot taken between `mmap_request` and the first
+    /// write to the requested page would lose the mmap state — the
+    /// receiving turbo86 wouldn't know to map the range and would
+    /// SIGSEGV on the first guest write.
+    reservations: Vec<Reservation>,
 }
 
 impl SysHost for WasmHost {
@@ -184,7 +194,16 @@ impl movie86::AbiHost for WasmHost {
                 self.active_video_mode = Some((value & 0xFF) as u8);
                 Ok(())
             }
-            movie86::CALL_MMAP_REQUEST => Ok(()),
+            movie86::CALL_MMAP_REQUEST => {
+                // Record the requested range so snapshotContext can
+                // hand it to the next engine as a Reservation. In wasm
+                // the page is already mapped via PT_LOAD so the call
+                // itself is a no-op, but a turbo86 receiving a mid-run
+                // snapshot can't know that without an explicit hint.
+                let (addr, size) = movie86::unpack_mmap_request(value);
+                self.reservations.push(Reservation { addr, size });
+                Ok(())
+            }
             movie86::CALL_EXIT => Err(Fault::Exit(value)),
             movie86::CALL_WRITE => {
                 let fd = regs[Reg32::Ebx as usize];
@@ -762,10 +781,14 @@ impl Vm {
             .expect("capture_sparse_regions inside FlatMemory's own extent should never fault");
         let region_addrs = regions.iter().map(|r| r.addr).collect();
         let region_bytes = regions.into_iter().map(|r| r.bytes).collect();
+        let reservation_addrs = self.host.reservations.iter().map(|r| r.addr).collect();
+        let reservation_sizes = self.host.reservations.iter().map(|r| r.size).collect();
         ContextSnapshot {
             regs,
             region_addrs,
             region_bytes,
+            reservation_addrs,
+            reservation_sizes,
         }
     }
 
@@ -850,6 +873,11 @@ pub struct ContextSnapshot {
     regs: CoreRegs,
     region_addrs: Vec<u32>,
     region_bytes: Vec<Vec<u8>>,
+    /// Parallel-array reservation storage. Same rationale as the region
+    /// arrays — keeps wasm-bindgen out of exporting `Vec<Reservation>`
+    /// (which would need its own wrapper type).
+    reservation_addrs: Vec<u32>,
+    reservation_sizes: Vec<u32>,
 }
 
 #[wasm_bindgen]
@@ -865,6 +893,8 @@ impl ContextSnapshot {
             regs: CoreRegs::default(),
             region_addrs: Vec::new(),
             region_bytes: Vec::new(),
+            reservation_addrs: Vec::new(),
+            reservation_sizes: Vec::new(),
         }
     }
 
@@ -909,6 +939,15 @@ impl ContextSnapshot {
     pub fn add_region(&mut self, addr: u32, bytes: Vec<u8>) {
         self.region_addrs.push(addr);
         self.region_bytes.push(bytes);
+    }
+
+    /// Append one reservation — a range the receiver must map before
+    /// resuming, even when no bytes for it appear in `regions` (the
+    /// ABI mmap_request side-effect carrier; see WasmHost::reservations).
+    #[wasm_bindgen(js_name = addReservation)]
+    pub fn add_reservation(&mut self, addr: u32, size: u32) {
+        self.reservation_addrs.push(addr);
+        self.reservation_sizes.push(size);
     }
 
     #[wasm_bindgen(getter)]
@@ -976,6 +1015,24 @@ impl ContextSnapshot {
     #[wasm_bindgen(js_name = regionBytesAt)]
     pub fn region_bytes_at(&self, idx: usize) -> Vec<u8> {
         self.region_bytes.get(idx).cloned().unwrap_or_default()
+    }
+
+    #[wasm_bindgen(getter, js_name = reservationCount)]
+    pub fn reservation_count(&self) -> usize {
+        self.reservation_addrs.len()
+    }
+
+    /// Addr of the `idx`-th reservation, or `u32::MAX` if out of range.
+    /// Same defensive shape as `regionAddrAt`.
+    #[wasm_bindgen(js_name = reservationAddrAt)]
+    pub fn reservation_addr_at(&self, idx: usize) -> u32 {
+        self.reservation_addrs.get(idx).copied().unwrap_or(u32::MAX)
+    }
+
+    /// Size of the `idx`-th reservation, or 0 if out of range.
+    #[wasm_bindgen(js_name = reservationSizeAt)]
+    pub fn reservation_size_at(&self, idx: usize) -> u32 {
+        self.reservation_sizes.get(idx).copied().unwrap_or(0)
     }
 }
 

--- a/movie86/wasm/src/lib.rs
+++ b/movie86/wasm/src/lib.rs
@@ -615,6 +615,21 @@ impl Vm {
         self.host.active_video_mode
     }
 
+    /// Externally set `active_video_mode` — used by the demo when a
+    /// turbo86 `VideoMode` Outbound arrives during handover. The
+    /// guest-driven paths (`int 0x10 / AH=0`, mov-only
+    /// `CALL_SET_VIDEO_MODE`) both update `host.active_video_mode`
+    /// directly inside `Cpu::step`; an Outbound event from turbo86
+    /// can't replay through those because it doesn't run guest
+    /// instructions on the local Vm. Writing the mode byte to the
+    /// ABI page via `writeMem` won't work either — the ABI page is
+    /// unmapped in `FlatMemory` (the CPU intercepts writes there at
+    /// dispatch time, not in memory), so the write silently no-ops.
+    #[wasm_bindgen(js_name = setActiveVideoMode)]
+    pub fn set_active_video_mode(&mut self, mode: u8) {
+        self.host.active_video_mode = Some(mode);
+    }
+
     #[wasm_bindgen(getter, js_name = memBase)]
     pub fn mem_base(&self) -> u32 {
         self.mem.base()

--- a/movie86/wasm/src/lib.rs
+++ b/movie86/wasm/src/lib.rs
@@ -689,6 +689,36 @@ impl Vm {
         buf
     }
 
+    /// Apply `bytes` into guest memory starting at `addr`. Bytes that
+    /// fall outside the Vm's mapped region are silently skipped;
+    /// returns the count of bytes actually written.
+    ///
+    /// Used by the demo when receiving a turbo86 `MemUpdate` Outbound
+    /// during a handover — the snapshot covers the wasm Vm's mapped
+    /// range plus turbo86's stub regions, and we want the canvas to
+    /// progressively reflect the in-flight decode without crashing on
+    /// regions (e.g. the stub's stack at 0x70000000+) that the wasm
+    /// Vm doesn't map.
+    #[wasm_bindgen(js_name = writeMem)]
+    pub fn write_mem(&mut self, addr: u32, bytes: &[u8]) -> u32 {
+        let base = self.mem.base();
+        let mem_end = u64::from(base) + self.mem.len() as u64;
+        let req_start = u64::from(addr);
+        let req_end = req_start.saturating_add(bytes.len() as u64);
+        let start = req_start.max(u64::from(base));
+        let end = req_end.min(mem_end);
+        if end <= start {
+            return 0;
+        }
+        let skip_head = (start - req_start) as usize;
+        let take_len = (end - start) as usize;
+        let slice = &bytes[skip_head..skip_head + take_len];
+        if self.mem.write_bytes(start as u32, slice).is_err() {
+            return 0;
+        }
+        take_len as u32
+    }
+
     /// Capture the canonical migration snapshot of the current guest
     /// state: 10-word register file (GPRs + EIP + EFLAGS) and the
     /// sparse memory regions (non-zero 4 KiB pages merged into runs).

--- a/movie86/wasm/tests/smoke.mjs
+++ b/movie86/wasm/tests/smoke.mjs
@@ -151,6 +151,20 @@ try {
         assert.equal(vm.activeVideoMode, undefined,
             `return42 shouldn't touch BIOS — activeVideoMode expected undefined, got ${vm.activeVideoMode}`);
 
+        // setActiveVideoMode is the seam the demo's turbo86 handover
+        // uses when a VideoMode Outbound arrives — turbo86 caught the
+        // ABI write on the native side, the local Vm needs the same
+        // mode reflected so `renderCanvases()` flips to the right
+        // canvas. Writing to the ABI page via writeMem would no-op
+        // (page is unmapped in FlatMemory), so we expose this direct
+        // setter and pin its semantics here.
+        vm.setActiveVideoMode(0x13);
+        assert.equal(vm.activeVideoMode, 0x13,
+            `setActiveVideoMode(0x13) didn't flip activeVideoMode — got ${vm.activeVideoMode}`);
+        vm.setActiveVideoMode(0x12);
+        assert.equal(vm.activeVideoMode, 0x12,
+            `setActiveVideoMode(0x12) didn't overwrite — got ${vm.activeVideoMode}`);
+
         console.log('ok  Vm introspection (return42)');
     } finally {
         vm.free();

--- a/movie86/wasm/tests/smoke.mjs
+++ b/movie86/wasm/tests/smoke.mjs
@@ -384,6 +384,95 @@ try {
     failed++;
 }
 
+// --- Reservations roundtrip via mmap_request → snapshotContext ---
+//
+// Pin the wire mechanism that keeps the canvas-mandelbrot post-
+// set_video_mode handover from SIGSEGVing. The FB page at 0xA0000 is
+// declared as a zero-filled PT_LOAD; once the guest executes
+// `mmap_request(FB13H_MMAP)` the wasm AbiHost records the requested
+// range. A snapshot taken right after must include that range as a
+// Reservation so turbo86 mmaps the page before resuming — otherwise
+// the next pixel write faults on an unmapped address. The smoke
+// fixture is a hand-crafted 1-page Vm so we can drive the ABI write
+// without depending on the full canvas_mandelbrot ELF.
+try {
+    // Build a minimal ELF that issues mmap_request then exits via
+    // CALL_EXIT (the mov-only equivalent of int 0x80 SYS_exit). We
+    // synthesize the ELF directly from canvas_smile's loader form by
+    // grabbing return42 (smallest committed ELF at 0x08048000) and
+    // overwriting its first 18 bytes with our test sequence.
+    //
+    // Bytes:
+    //   B8 3F 00 0A 00   mov eax, 0xA003F   (packed: addr 0xA0000 | (64-1))
+    //   A3 20 00 FE 1F   mov [0x1FFE0020], eax  ; ABI mmap_request
+    //   B8 00 00 00 00   mov eax, 0          (exit code)
+    //   A3 FE 00 FE 1F   mov [0x1FFE00FE], eax  ; CALL_EXIT
+    //                                            (return 0; total 20 bytes)
+    const seq = new Uint8Array([
+        0xB8, 0x3F, 0x00, 0x0A, 0x00,
+        0xA3, 0x20, 0x00, 0xFE, 0x1F,
+        0xB8, 0x00, 0x00, 0x00, 0x00,
+        0xA3, 0xFE, 0x00, 0xFE, 0x1F,
+    ]);
+    // The committed canvas_bars.elf has a 33-byte .text at 0x08048000
+    // and declares a PT_LOAD covering 0xA0000 (so the FlatMemory base
+    // already includes the FB extent). Reuse it as a substrate.
+    const elf = new Uint8Array(await readFile(`${root}/examples/canvas_bars.elf`));
+    const vm = new mod.Vm(elf);
+    try {
+        // Overwrite the entry's first 20 bytes with our mov-only ABI
+        // sequence. writeMem returns the count of bytes actually
+        // applied — should equal seq.length since the .text segment
+        // is mapped at vm.eip.
+        const wrote = vm.writeMem(vm.eip, seq);
+        assert.equal(wrote, seq.length,
+            `couldn't overwrite entry with mov-only ABI sequence: writeMem returned ${wrote}`);
+
+        // Run until halt — Cpu emits Fault::Exit on CALL_EXIT, surfaced
+        // as a haltReason. Twenty bytes = 4 instructions, well under
+        // the smoke loop's batch budget.
+        while (!vm.haltReason) vm.stepN(100n);
+        assert.equal(vm.exitCode, 0,
+            `mov-only ABI sequence should exit 0, got exit=${vm.exitCode} halt=${vm.haltReason}`);
+
+        // snapshotContext must now carry the reservation populated by
+        // the mmap_request side-effect: addr 0xA0000, size 64 pages
+        // (0x40000 bytes).
+        const ctx = wrapper.snapshotContext(vm);
+        assert.ok(Array.isArray(ctx.reservations),
+            `snapshotContext().reservations should be an array, got ${typeof ctx.reservations}`);
+        assert.equal(ctx.reservations.length, 1,
+            `expected 1 reservation from mmap_request, got ${ctx.reservations.length}`);
+        assert.equal(ctx.reservations[0].addr, 0x000A_0000,
+            `reservation addr ${ctx.reservations[0].addr.toString(16)} != 0xA0000`);
+        assert.equal(ctx.reservations[0].size, 64 * 0x1000,
+            `reservation size ${ctx.reservations[0].size} != 64 * 4 KiB`);
+
+        // Wire encoding: reservations show up as an array of
+        // `{addr, size}` under context.reservations, matching
+        // turbo86's `proto.Reservation` JSON shape byte-for-byte.
+        const frame = JSON.parse(wrapper.makeLoadContextMessage(ctx, 'host'));
+        assert.deepEqual(frame.context.reservations,
+            [{ addr: 0x000A_0000, size: 64 * 0x1000 }],
+            `wire reservations mismatch: ${JSON.stringify(frame.context.reservations)}`);
+
+        // And: an empty-reservation snapshot must NOT emit the field,
+        // matching Go's `omitempty` so old turbo86 builds keep
+        // accepting payloads.
+        const emptyCtx = { regs: ctx.regs, regions: [], reservations: [] };
+        const emptyFrame = JSON.parse(wrapper.makeLoadContextMessage(emptyCtx, 'host'));
+        assert.ok(!('reservations' in emptyFrame.context),
+            `empty reservations should be omitted from wire, got: ${JSON.stringify(emptyFrame.context)}`);
+
+        console.log('ok  reservations roundtrip (mmap_request → snapshotContext → wire)');
+    } finally {
+        vm.free();
+    }
+} catch (e) {
+    console.error(`FAIL reservations roundtrip: ${e.stack || e.message}`);
+    failed++;
+}
+
 // --- cycle.elf: partial-step decode coverage ---
 //
 // The other fixtures terminate, so the runElf parity loop above ends

--- a/movie86/wasm/tests/turbo86_handover.mjs
+++ b/movie86/wasm/tests/turbo86_handover.mjs
@@ -347,6 +347,141 @@ async function main() {
             console.error(`FAIL real turbo86 handover (write): ${e.message}`);
             failed++;
         }
+
+        // VideoMode Outbound + setActiveVideoMode round-trip. This is
+        // the canvas-rendering path: turbo86 catches a `mov [ABI+0x010],
+        // al` (CALL_SET_VIDEO_MODE) and emits a VideoMode event; the
+        // frontend has to flip the local Vm's activeVideoMode so the
+        // canvas pane picks the right FB region. An earlier version
+        // wrote the mode byte to the ABI page via `writeMem` — but the
+        // ABI page is unmapped in FlatMemory, so the write silently
+        // no-oped and the canvas placeholder stayed visible. The fix
+        // (lib.rs::setActiveVideoMode) is what this pin guards.
+        try {
+            // Guest: mov al, 0x13 ; mov [0x1FFE0010], al ; mov eax, 1 ;
+            // mov ebx, 0 ; int 0x80 — sets mode 13h via the mov-only
+            // ABI then exits 0. The ABI write triggers VideoMode on
+            // both host and trap mode (signal-dispatch policy is past
+            // the ABI gate).
+            const setModeCode = new Uint8Array([
+                0xB0, 0x13,                   // mov al, 0x13
+                0xA2, 0x10, 0x00, 0xFE, 0x1F, // mov [0x1FFE0010], al
+                0xB8, 0x01, 0x00, 0x00, 0x00, // mov eax, 1   (SYS_exit)
+                0xBB, 0x00, 0x00, 0x00, 0x00, // mov ebx, 0
+                0xCD, 0x80,                   // int 0x80
+            ]);
+            const events = await runHandover(
+                { regs: { ...ctx.regs }, regions: [{ addr: 0x08048000, bytes: setModeCode }] },
+                'host',
+            );
+            const videoMode = events.find(e => e.type === 'video_mode');
+            assert.ok(videoMode,
+                `expected video_mode event, got types=${events.map(e => e.type).join(',')}`);
+            assert.equal(videoMode.mode, 0x13,
+                `VideoMode.mode = ${videoMode.mode}, expected 0x13`);
+
+            // Now exercise the frontend response: a fresh Vm has no
+            // active mode; setActiveVideoMode(videoMode.mode) must
+            // flip it. This is what index.html's `case 'video_mode'`
+            // does — pin the seam end-to-end so a regression on
+            // either side fires.
+            const elfBytes = new Uint8Array(
+                await readFile(`${root}/examples/return42.elf`),
+            );
+            const vm = new wasmMod.Vm(elfBytes);
+            try {
+                assert.equal(vm.activeVideoMode, undefined,
+                    `fresh Vm should have undefined activeVideoMode, got ${vm.activeVideoMode}`);
+                vm.setActiveVideoMode(videoMode.mode);
+                assert.equal(vm.activeVideoMode, 0x13,
+                    `setActiveVideoMode(0x13) didn't flip activeVideoMode — got ${vm.activeVideoMode}`);
+            } finally {
+                vm.free();
+            }
+            console.log('ok  real turbo86 handover (VideoMode → setActiveVideoMode flips mode)');
+        } catch (e) {
+            console.error(`FAIL VideoMode E2E: ${e.stack || e.message}`);
+            failed++;
+        }
+
+        // MemUpdate Outbound + writeMem round-trip. Pin the periodic-
+        // snapshot path: LoadContext carries `mem_update_interval_ms`,
+        // turbo86 emits MemUpdate events while the guest runs, the
+        // frontend applies each region's bytes to the local Vm via
+        // writeMem. We drive a tight jmp-self loop so the only events
+        // turbo86 emits are MemUpdates (no Exit until Pause), then
+        // Pause to terminate.
+        try {
+            const entry = 0x08048000;
+            // jmp $ (EB FE — 2-byte tight loop) at entry. We seed an
+            // arbitrary sentinel byte right after so we can prove the
+            // MemUpdate carried real memory bytes back to us.
+            const sentinelOffset = 2;
+            const sentinel = 0x5A;
+            const tightLoop = new Uint8Array([0xEB, 0xFE, sentinel]);
+            const loopCtx = {
+                regs: {
+                    eax: 0, ebx: 0, ecx: 0, edx: 0,
+                    esi: 0, edi: 0, ebp: 0,
+                    esp: 0x701FFFF0, eip: entry, eflags: 0,
+                },
+                regions: [{ addr: entry, bytes: tightLoop }],
+            };
+
+            const url = `ws://127.0.0.1:${port}/`;
+            const ws = new WebSocket(url);
+            const events = [];
+            const done = new Promise((resolve, reject) => {
+                ws.addEventListener('open', () => {
+                    ws.send(wrapper.makeLoadContextMessage(loopCtx, 'host', 50));
+                    // Give the ticker a few cadences (50 ms × ~6 = ~300 ms)
+                    // so we definitely see multiple MemUpdate events,
+                    // then Pause to drain.
+                    setTimeout(() => ws.send(JSON.stringify({ type: 'pause' })), 300);
+                }, { once: true });
+                ws.addEventListener('message', (e) => {
+                    events.push(wrapper.parseOutboundMessage(e.data));
+                });
+                ws.addEventListener('close', resolve, { once: true });
+                ws.addEventListener('error', reject, { once: true });
+            });
+            await done;
+
+            const memUpdates = events.filter(e => e.type === 'mem_update');
+            assert.ok(memUpdates.length >= 2,
+                `expected ≥2 MemUpdate events at 50 ms cadence over 300 ms, got ${memUpdates.length}`);
+
+            // Pick the first MemUpdate whose regions contain entry —
+            // turbo86 may also include stack regions. Apply via the
+            // same writeMem path the frontend uses, then verify the
+            // sentinel byte lands at entry+2.
+            const elfBytes = new Uint8Array(
+                await readFile(`${root}/examples/return42.elf`),
+            );
+            const vm = new wasmMod.Vm(elfBytes);
+            try {
+                const update = memUpdates.find(u =>
+                    u.regions.some(r =>
+                        r.addr <= entry && entry < r.addr + r.bytes.length));
+                assert.ok(update,
+                    `no MemUpdate covered entry ${entry.toString(16)}`);
+                let applied = 0;
+                for (const r of update.regions) {
+                    applied += vm.writeMem(r.addr, r.bytes);
+                }
+                assert.ok(applied > 0,
+                    `writeMem applied 0 bytes from MemUpdate — frontend would render an empty canvas`);
+                const at = vm.readMem(entry, 3);
+                assert.deepEqual(Array.from(at), [0xEB, 0xFE, sentinel],
+                    `MemUpdate bytes at entry round-trip mismatch: got ${Array.from(at)}`);
+            } finally {
+                vm.free();
+            }
+            console.log(`ok  real turbo86 handover (MemUpdate ×${memUpdates.length} → writeMem applies bytes)`);
+        } catch (e) {
+            console.error(`FAIL MemUpdate E2E: ${e.stack || e.message}`);
+            failed++;
+        }
     } finally {
         child.kill('SIGTERM');
         if (bin.cleanup) await bin.cleanup();

--- a/movie86/wasm/tests/turbo86_handover.mjs
+++ b/movie86/wasm/tests/turbo86_handover.mjs
@@ -482,6 +482,51 @@ async function main() {
             console.error(`FAIL MemUpdate E2E: ${e.stack || e.message}`);
             failed++;
         }
+
+        // Reservations E2E. Without it, a canvas demo that handed over
+        // mid-flight (post-mmap_request, pre-first-FB-write) would
+        // SIGSEGV on the next pixel store: the sender's mmap_request
+        // side-effect is invisible in Regs/Regions, the receiver has
+        // no idea the page is supposed to be mapped, and a write to
+        // 0xA0000 traps. The Reservation roundtrip lets turbo86
+        // replay the mmap at LoadContext so the same write succeeds.
+        try {
+            const entry = 0x08048000;
+            const fbAddr = 0x000A_0000;
+            // Guest: mov [0xA0000], 0x12345678 ; mov eax, 1 ;
+            // mov ebx, 42 ; int 0x80. The write tests the page was
+            // actually mapped (a SIGSEGV would surface as Paused
+            // signal=11 with no Exit).
+            const code = new Uint8Array([
+                0xC7, 0x05, 0x00, 0x00, 0x0A, 0x00, 0x78, 0x56, 0x34, 0x12,
+                0xB8, 0x01, 0x00, 0x00, 0x00,
+                0xBB, 0x2A, 0x00, 0x00, 0x00,
+                0xCD, 0x80,
+            ]);
+            const ctxWithReservation = {
+                regs: {
+                    eax: 0, ebx: 0, ecx: 0, edx: 0,
+                    esi: 0, edi: 0, ebp: 0,
+                    esp: 0x701FFFF0,
+                    eip: entry,
+                    eflags: 0,
+                },
+                regions: [{ addr: entry, bytes: code }],
+                reservations: [{ addr: fbAddr, size: 0x1000 }],
+            };
+            const events = await runHandover(ctxWithReservation, 'host');
+            assert.equal(events.length, 1,
+                `expected 1 event (Exit), got ${events.length} (Paused → Reservation handling failed?)`);
+            assert.equal(events[0].type, 'exit',
+                `expected exit (not ${events[0].type} signal=${events[0].signal ?? '-'})`);
+            assert.equal(events[0].code, 42,
+                `expected exit 42, got ${events[0].code}`);
+
+            console.log('ok  real turbo86 handover (Reservation → FB page mmap\'d → guest writes succeed)');
+        } catch (e) {
+            console.error(`FAIL Reservation E2E: ${e.stack || e.message}`);
+            failed++;
+        }
     } finally {
         child.kill('SIGTERM');
         if (bin.cleanup) await bin.cleanup();

--- a/turbo86/proto/proto.go
+++ b/turbo86/proto/proto.go
@@ -90,6 +90,19 @@ type MemRegion struct {
 	Bytes []byte `json:"bytes"`
 }
 
+// Reservation declares an address range that must be mapped on the
+// receiver before the guest resumes, even when the sender's snapshot
+// carries no bytes for it (e.g. an all-zero framebuffer page the
+// sparse-region walk skipped). Concretely the guest may have already
+// issued a mov-only ABI `mmap_request` on the sender — that side
+// effect is invisible in Regs/Regions, so we record it here so the
+// receiver can replay the mmap. Addr and Size are in guest bytes;
+// the receiver page-aligns internally.
+type Reservation struct {
+	Addr uint32 `json:"addr"`
+	Size uint32 `json:"size"`
+}
+
 // Context is a transferable snapshot of guest execution: enough state
 // for either engine to pick up from where the other left off. The
 // receiver loads memory regions first, then sets Regs, then resumes
@@ -99,9 +112,15 @@ type MemRegion struct {
 // v1 ships the simplest workable schema — full memory in Regions, no
 // signal disposition, no generation counter. Both can be added later
 // without breaking existing payloads (additive JSON fields).
+//
+// Reservations are additive: pages the receiver must mmap before
+// resuming, even though they carry no bytes in Regions. Needed for
+// ABI mmap_request side effects (e.g. a mode-13h framebuffer that
+// was still all-zero when the snapshot was taken).
 type Context struct {
-	Regs    Regs        `json:"regs"`
-	Regions []MemRegion `json:"regions"`
+	Regs         Regs          `json:"regs"`
+	Regions      []MemRegion   `json:"regions"`
+	Reservations []Reservation `json:"reservations,omitempty"`
 }
 
 // LoadContext hands a Context to the runner: write each MemRegion into

--- a/turbo86/proto/proto.go
+++ b/turbo86/proto/proto.go
@@ -48,10 +48,18 @@ const (
 
 // Start sets the guest's initial EIP and ESP and begins execution.
 // Sent after the Code messages that supply the entry-point's code.
+//
+// `MemUpdateIntervalMs` opts the session into periodic mid-run
+// memory snapshots — turbo86 will SIGSTOP the guest every N ms,
+// snapshot the sparse non-zero pages, emit `MemUpdate{Regions}`, and
+// resume. 0 (the default) disables it; the session emits no mid-run
+// memory events, matching the original behavior. Typical value for a
+// browser frontend driving a canvas: 100ms.
 type Start struct {
-	Entry    uint32 `json:"entry"`
-	StackTop uint32 `json:"stack_top"`
-	Mode     Mode   `json:"mode,omitempty"`
+	Entry               uint32 `json:"entry"`
+	StackTop            uint32 `json:"stack_top"`
+	Mode                Mode   `json:"mode,omitempty"`
+	MemUpdateIntervalMs uint32 `json:"mem_update_interval_ms,omitempty"`
 }
 
 func (Start) inboundKind() string { return "start" }
@@ -102,8 +110,9 @@ type Context struct {
 // turbo86 for the hot path. Mode picks the execution policy; empty
 // defaults to "host".
 type LoadContext struct {
-	Context Context `json:"context"`
-	Mode    Mode    `json:"mode,omitempty"`
+	Context             Context `json:"context"`
+	Mode                Mode    `json:"mode,omitempty"`
+	MemUpdateIntervalMs uint32  `json:"mem_update_interval_ms,omitempty"`
 }
 
 func (LoadContext) inboundKind() string { return "load_context" }
@@ -276,6 +285,25 @@ type VideoMode struct {
 
 func (VideoMode) outboundKind() string { return "video_mode" }
 
+// MemUpdate reports a periodic mid-session snapshot of guest memory
+// regions. Same sparse `MemRegion` shape Paused uses, but it's an
+// *intermediate* event — the session is still running — so a peer
+// engine can keep its own view of guest memory in sync for
+// progressive display (canvas filling in as a decoder writes pixels,
+// etc.) without waiting for terminal Paused / Exit.
+//
+// Cadence is configured at session start via Start.MemUpdateIntervalMs
+// / LoadContext.MemUpdateIntervalMs (default 0 = disabled). While
+// enabled, the runner periodically SIGSTOPs the guest, captures the
+// non-zero pages, emits one MemUpdate, and resumes. The guest never
+// sees the stop — `SIGSTOP` is non-forwardable and the snapshot path
+// doesn't dispatch into the guest's signal table.
+type MemUpdate struct {
+	Regions []MemRegion `json:"regions"`
+}
+
+func (MemUpdate) outboundKind() string { return "mem_update" }
+
 // MarshalOutbound encodes an Outbound as a JSON object with a "type" field.
 func MarshalOutbound(msg Outbound) ([]byte, error) {
 	switch m := msg.(type) {
@@ -308,6 +336,11 @@ func MarshalOutbound(msg Outbound) ([]byte, error) {
 		return json.Marshal(struct {
 			Type string `json:"type"`
 			VideoMode
+		}{m.outboundKind(), m})
+	case MemUpdate:
+		return json.Marshal(struct {
+			Type string `json:"type"`
+			MemUpdate
 		}{m.outboundKind(), m})
 	default:
 		return nil, fmt.Errorf("proto: unknown Outbound type %T", msg)
@@ -358,6 +391,12 @@ func UnmarshalOutbound(data []byte) (Outbound, error) {
 		var m VideoMode
 		if err := json.Unmarshal(data, &m); err != nil {
 			return nil, fmt.Errorf("proto: parsing VideoMode payload: %w", err)
+		}
+		return m, nil
+	case "mem_update":
+		var m MemUpdate
+		if err := json.Unmarshal(data, &m); err != nil {
+			return nil, fmt.Errorf("proto: parsing MemUpdate payload: %w", err)
 		}
 		return m, nil
 	default:

--- a/turbo86/proto/proto_test.go
+++ b/turbo86/proto/proto_test.go
@@ -65,6 +65,22 @@ func TestInboundRoundTrip(t *testing.T) {
 				Regions: []MemRegion{},
 			}},
 		},
+		{
+			// Reservations cover ABI mmap_request pages: the sender's
+			// snapshot ran past the request but the page is all-zero
+			// so it wouldn't appear in Regions. Receiver must mmap
+			// the range before resuming so the next guest write
+			// doesn't SIGSEGV. mode 13h VGA-style framebuffer is the
+			// motivating case (64 pages from 0xA0000).
+			"LoadContext with reservations (FB mmap roundtrip)",
+			LoadContext{Context: Context{
+				Regs:    Regs{Eip: 0x08048000, Esp: 0x701FFFF0},
+				Regions: []MemRegion{{Addr: 0x08048000, Bytes: []byte{0xCD, 0x80}}},
+				Reservations: []Reservation{
+					{Addr: 0x000A_0000, Size: 64 * 0x1000},
+				},
+			}},
+		},
 		{"Stop", Stop{}},
 		{"Pause", Pause{}},
 	}

--- a/turbo86/proto/proto_test.go
+++ b/turbo86/proto/proto_test.go
@@ -28,6 +28,23 @@ func TestInboundRoundTrip(t *testing.T) {
 			Start{Entry: 0, StackTop: 0},
 		},
 		{
+			"Start with periodic MemUpdate cadence",
+			Start{
+				Entry: 0x08048000, StackTop: 0x70200000,
+				Mode: ModeHost, MemUpdateIntervalMs: 100,
+			},
+		},
+		{
+			"LoadContext with MemUpdate interval",
+			LoadContext{
+				Context: Context{
+					Regs:    Regs{Eip: 0x08048000, Esp: 0x701FFFF0},
+					Regions: []MemRegion{{Addr: 0x08048000, Bytes: []byte{0xCD, 0x80}}},
+				},
+				MemUpdateIntervalMs: 50,
+			},
+		},
+		{
 			"LoadContext typical",
 			LoadContext{Context: Context{
 				Regs: Regs{
@@ -102,6 +119,23 @@ func TestOutboundRoundTrip(t *testing.T) {
 		},
 		{"VideoMode 13h", VideoMode{Mode: 0x13}},
 		{"VideoMode 12h", VideoMode{Mode: 0x12}},
+		{
+			"MemUpdate empty regions",
+			MemUpdate{Regions: nil},
+		},
+		{
+			"MemUpdate one region",
+			MemUpdate{Regions: []MemRegion{
+				{Addr: 0x000A_0000, Bytes: []byte{0xff, 0x00, 0x00, 0xff}},
+			}},
+		},
+		{
+			"MemUpdate multiple regions",
+			MemUpdate{Regions: []MemRegion{
+				{Addr: 0x000A_0000, Bytes: []byte{0x01, 0x02, 0x03, 0x04}},
+				{Addr: 0x000B_0000, Bytes: []byte{0x05, 0x06}},
+			}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/turbo86/runner/context_test.go
+++ b/turbo86/runner/context_test.go
@@ -44,6 +44,61 @@ func TestRunWithContext_ResumesFromMidState(t *testing.T) {
 	}
 }
 
+// TestRunWithContext_Reservations_MapsFBPageBeforeFirstWrite models
+// the canvas demo's post-set_video_mode handover: the sender's snapshot
+// stops just after `mmap_request(FB)` + `set_video_mode(0x13)` but
+// BEFORE any pixel write, so the FB page is still all-zero and the
+// sparse-region walk skipped it. Without a Reservation carrying the
+// FB range, turbo86 has no idea the guest's next instruction will
+// touch 0xA0000 → SIGSEGV on the first pixel write. With the
+// Reservation the runner mmaps the page at LoadContext time and the
+// write succeeds.
+//
+// Regression for the case the user hit in PR #51: late-handover canvas
+// mandelbrot crashed at the first FB write because the page was never
+// in Regions.
+func TestRunWithContext_Reservations_MapsFBPageBeforeFirstWrite(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	const entry uint32 = 0x08048000
+	const fbAddr uint32 = 0x000A_0000
+	// Code:
+	//   C7 05 00 00 0A 00 78 56 34 12   mov [0xA0000], 0x12345678
+	//   B8 01 00 00 00                  mov eax, 1   (SYS_exit)
+	//   BB 2A 00 00 00                  mov ebx, 42
+	//   CD 80                           int 0x80
+	code := []byte{
+		0xC7, 0x05, 0x00, 0x00, 0x0A, 0x00, 0x78, 0x56, 0x34, 0x12,
+		0xB8, 0x01, 0x00, 0x00, 0x00,
+		0xBB, 0x2A, 0x00, 0x00, 0x00,
+		0xCD, 0x80,
+	}
+
+	ctx := proto.Context{
+		Regs: proto.Regs{
+			Esp: 0x701FFFF0,
+			Eip: entry,
+		},
+		Regions: []proto.MemRegion{{Addr: entry, Bytes: code}},
+		Reservations: []proto.Reservation{
+			// One 4 KiB page covering the write. Pin the explicit
+			// size rather than the canvas mode's 64 pages because
+			// this test only cares about the wire mechanism.
+			{Addr: fbAddr, Size: 0x1000},
+		},
+	}
+
+	events, err := RunWithContext(stub.Bytes, ctx)
+	if err != nil {
+		t.Fatalf("RunWithContext: %v", err)
+	}
+	want := []proto.Outbound{proto.Exit{Code: 42}}
+	if !reflect.DeepEqual(events, want) {
+		t.Errorf("events (Reservation handling missing? expect Exit 42, not SIGSEGV):\n  got:  %#v\n  want: %#v", events, want)
+	}
+}
+
 // TestRunWithContext_TransfersAllGPRegs sanity-checks that *each* GP
 // register in Context.Regs makes it into the child by having a guest
 // program inspect them. The program copies ebx → memory, then exits

--- a/turbo86/runner/memupdate_test.go
+++ b/turbo86/runner/memupdate_test.go
@@ -1,0 +1,193 @@
+//go:build linux
+
+package runner
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/sksat/x86.mov/turbo86/proto"
+	"github.com/sksat/x86.mov/turbo86/stub"
+)
+
+// TestRunner_MemUpdateTicker_EmitsMidRun pins the periodic
+// `proto.MemUpdate` cadence: with `RunWithModeAndMemUpdate(..., 50ms)`
+// a guest stuck in a no-syscall tight loop should still produce a
+// stream of MemUpdate events without ending the session. Without the
+// ticker the same fixture (jmp short -2) sees zero events until
+// something kills it.
+func TestRunner_MemUpdateTicker_EmitsMidRun(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	const entry uint32 = 0x08048000
+	loop := []byte{0xEB, 0xFE} // jmp short -2, no syscalls
+
+	r, err := New(stub.Bytes)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Don't defer Close here — the eventsCh is unbuffered so Close
+	// would deadlock if the tracer is mid-emit when we stop reading.
+	// We Close + drain at the end of the test instead.
+
+	if err := r.WriteCode(entry, loop); err != nil {
+		t.Fatalf("WriteCode: %v", err)
+	}
+
+	events := r.RunWithModeAndMemUpdate(
+		entry, 0x701FFFF0, proto.ModeHost, 50*time.Millisecond,
+	)
+
+	// 250ms gives ~5 ticks at 50ms cadence; back-pressure can drop
+	// some so we require ≥ 2 to be robust against scheduling jitter.
+	const want = 2
+	deadline := time.After(2 * time.Second)
+	var got int
+loop_events:
+	for got < want {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				t.Fatalf("events channel closed before %d MemUpdates (got %d)", want, got)
+			}
+			if _, isMemUpdate := ev.(proto.MemUpdate); isMemUpdate {
+				got++
+			} else {
+				t.Logf("non-MemUpdate event during periodic ticker: %T %#v", ev, ev)
+			}
+		case <-deadline:
+			break loop_events
+		}
+	}
+
+	// Tear down: kick a draining goroutine first so the tracer can
+	// finish its in-flight MemUpdate send (eventsCh is unbuffered),
+	// then Close() — drain exits when eventsCh closes.
+	done := make(chan struct{})
+	go func() {
+		for range events {
+		}
+		close(done)
+	}()
+	_ = r.Close()
+	<-done
+
+	if got < want {
+		t.Errorf("got %d MemUpdate events in 2s, want ≥ %d", got, want)
+	}
+}
+
+// TestRunner_MemUpdateZeroInterval_NoMemUpdate keeps the default
+// behavior honest: when `memUpdateInterval == 0` (the existing Run /
+// RunWithMode entry points), the session should never emit a
+// MemUpdate. Catches a regression where the ticker would fire even
+// without an explicit opt-in.
+func TestRunner_MemUpdateZeroInterval_NoMemUpdate(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	const entry uint32 = 0x08048000
+	loop := []byte{0xEB, 0xFE}
+
+	r, err := New(stub.Bytes)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := r.WriteCode(entry, loop); err != nil {
+		t.Fatalf("WriteCode: %v", err)
+	}
+
+	events := r.RunWithMode(entry, 0x701FFFF0, proto.ModeHost)
+
+	deadline := time.After(300 * time.Millisecond)
+	sawMemUpdate := false
+loop_check:
+	for {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				break loop_check
+			}
+			if _, isMemUpdate := ev.(proto.MemUpdate); isMemUpdate {
+				sawMemUpdate = true
+				break loop_check
+			}
+		case <-deadline:
+			break loop_check
+		}
+	}
+
+	// Teardown drainer + Close (see TestRunner_MemUpdateTicker for why).
+	done := make(chan struct{})
+	go func() {
+		for range events {
+		}
+		close(done)
+	}()
+	_ = r.Close()
+	<-done
+
+	if sawMemUpdate {
+		t.Error("MemUpdate emitted with no interval configured")
+	}
+}
+
+// TestRunner_MemUpdateAndPauseCoexist makes sure the user's Pause()
+// signal isn't accidentally consumed by the periodic snapshot
+// consumer. Same fixture as the ticker test; after a few ticks we
+// call Pause and expect a Paused (terminal) to land after the most
+// recent MemUpdate, ending the session normally.
+func TestRunner_MemUpdateAndPauseCoexist(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	const entry uint32 = 0x08048000
+	loop := []byte{0xEB, 0xFE}
+
+	r, err := New(stub.Bytes)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// No defer Close — Pause winds the session down.
+
+	if err := r.WriteCode(entry, loop); err != nil {
+		t.Fatalf("WriteCode: %v", err)
+	}
+
+	events := r.RunWithModeAndMemUpdate(
+		entry, 0x701FFFF0, proto.ModeHost, 50*time.Millisecond,
+	)
+
+	// Let a few ticks accumulate before calling Pause.
+	time.Sleep(200 * time.Millisecond)
+	if err := r.Pause(); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	var memUpdates int
+	var sawPaused bool
+	for !sawPaused {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				t.Fatalf("events channel closed before Paused (memUpdates=%d)", memUpdates)
+			}
+			switch ev.(type) {
+			case proto.MemUpdate:
+				memUpdates++
+			case proto.Paused:
+				sawPaused = true
+			}
+		case <-deadline:
+			t.Fatalf("Paused did not arrive after Pause (memUpdates=%d)", memUpdates)
+		}
+	}
+	if memUpdates == 0 {
+		t.Error("expected at least one MemUpdate before Pause (back-pressure or " +
+			"snapshotPending race ate every one)")
+	}
+}

--- a/turbo86/runner/runner.go
+++ b/turbo86/runner/runner.go
@@ -303,7 +303,16 @@ func (r *Runner) snapshotMemory() ([]proto.MemRegion, error) {
 			return nil, err
 		}
 	}
-	for _, gr := range r.extraRegions {
+	// Copy extraRegions under the lock so the tracer goroutine can
+	// still append (mmap_request handler) without racing the walk.
+	// The async MemUpdate ticker is the other reader; without the
+	// snapshot under lock a guest that calls mmap_request mid-run
+	// would trigger a Go data race on the slice header.
+	r.extraRegionsMu.RLock()
+	extras := make([]struct{ addr, size uint32 }, len(r.extraRegions))
+	copy(extras, r.extraRegions)
+	r.extraRegionsMu.RUnlock()
+	for _, gr := range extras {
 		if err := walk(gr.addr, gr.size); err != nil {
 			return nil, err
 		}
@@ -399,13 +408,24 @@ type Runner struct {
 	done      chan struct{}
 	closeOnce sync.Once
 
-	// tickerStop is closed by the tracer goroutine's defer as the
-	// very first step of teardown, *before* it closes eventsCh. The
-	// MemUpdate ticker (if running) watches this channel and exits
-	// without sending — otherwise a tick fired between syscallLoop
-	// returning and the ticker noticing closeCh would panic with
-	// "send on closed channel". Created in `New`.
+	// tickerStop is closed by the tracer goroutine's defer to signal
+	// the MemUpdate ticker (if running) to wind down, and tickerWg
+	// is the join handle the defer waits on **before** closing
+	// eventsCh. Without the wait the ticker's `select { send,
+	// tickerStop }` could pick the send case after we've closed
+	// eventsCh and panic with "send on closed channel" — a real
+	// hazard when a terminal event races a pending MemUpdate.
+	// Created in `New`.
 	tickerStop chan struct{}
+	tickerWg   sync.WaitGroup
+
+	// extraRegionsMu guards extraRegions against concurrent access
+	// between the tracer goroutine (which appends in the mmap_request
+	// ABI path) and the MemUpdate ticker goroutine (which iterates the
+	// slice via snapshotMemory). Without it a guest that grows its
+	// address space mid-session triggers a Go data race on the slice
+	// header.
+	extraRegionsMu sync.RWMutex
 
 	// Mode-dependent state, populated when the syscall loop starts.
 	mode       proto.Mode       // host (default) or trap
@@ -593,11 +613,15 @@ func (r *Runner) tracerLoop(stubBytes []byte, bootErr chan<- error) {
 	// Single defer covers all exit paths (bootstrap failure, pre-Run
 	// close, post-Run close, natural session end).
 	defer func() {
-		// Signal the periodic MemUpdate ticker (if any) to stop
-		// before we close eventsCh — otherwise a tick fired between
-		// syscallLoop returning and the ticker noticing would panic
-		// with "send on closed channel".
+		// Signal the periodic MemUpdate ticker to stop AND join its
+		// goroutine before closing eventsCh. Without the join the
+		// ticker's `select { send_to_eventsCh, <-tickerStop }` can
+		// observe the send case becoming "ready for evaluation" (Go
+		// makes no ordering guarantees on which case fires when
+		// multiple ready cases exist) and then panic when
+		// `close(eventsCh)` lands mid-pick.
 		close(r.tickerStop)
+		r.tickerWg.Wait()
 		if r.cmd != nil && r.cmd.Process != nil {
 			_ = r.cmd.Process.Kill() // no-op if already dead
 			var ws syscall.WaitStatus
@@ -692,12 +716,16 @@ func (r *Runner) tracerLoop(stubBytes []byte, bootErr chan<- error) {
 		return
 	}
 
-	// Start the periodic MemUpdate ticker, if the caller asked for one.
-	// Stopped by closing `closeCh` (Close()) or the syscallLoop
-	// returning naturally (the loop's defer drains by sending SIGKILL,
-	// which closes the ticker's only effective recipient).
+	// Start the periodic MemUpdate ticker, if the caller asked for
+	// one. tracerLoop's defer joins via `tickerWg.Wait()` before
+	// closing eventsCh so the ticker can't panic on a closed
+	// channel.
 	if msg.memUpdateInterval > 0 {
-		go r.memUpdateTicker(msg.memUpdateInterval)
+		r.tickerWg.Add(1)
+		go func() {
+			defer r.tickerWg.Done()
+			r.memUpdateTicker(msg.memUpdateInterval)
+		}()
 	}
 
 	r.syscallLoop(&regs)
@@ -969,9 +997,12 @@ func regionFitsStaticGuest(addr, size uint32) bool {
 // same ptrace mechanics. Only difference is *when* it's called (init
 // vs mid-execution); the child is stopped in both cases.
 func (r *Runner) mmapRegionForLoadContext(addr, size uint32, regs *regs32) error {
+	r.extraRegionsMu.RLock()
 	if len(r.extraRegions) >= mmapMaxRegions {
+		r.extraRegionsMu.RUnlock()
 		return fmt.Errorf("too many dynamic regions (cap=%d)", mmapMaxRegions)
 	}
+	r.extraRegionsMu.RUnlock()
 	pageAddr := addr & mmapAddrMask
 	pageEnd := (addr + size + 0xFFF) & mmapAddrMask
 	if pageEnd <= pageAddr {
@@ -986,7 +1017,9 @@ func (r *Runner) mmapRegionForLoadContext(addr, size uint32, regs *regs32) error
 	if ret != pageAddr {
 		return fmt.Errorf("mmap returned 0x%x, asked for 0x%x", ret, pageAddr)
 	}
+	r.extraRegionsMu.Lock()
 	r.extraRegions = append(r.extraRegions, struct{ addr, size uint32 }{pageAddr, pageSize})
+	r.extraRegionsMu.Unlock()
 	return nil
 }
 
@@ -1035,7 +1068,10 @@ func (r *Runner) handleAbiWrite(regs *regs32) bool {
 // progress without the region it asked for, and silent partial success
 // would let the next mov into that range fault confusingly.
 func (r *Runner) handleMmapRequest(call abiCall, regs *regs32) bool {
-	if len(r.extraRegions) >= mmapMaxRegions {
+	r.extraRegionsMu.RLock()
+	full := len(r.extraRegions) >= mmapMaxRegions
+	r.extraRegionsMu.RUnlock()
+	if full {
 		r.emitFault(fmt.Sprintf(
 			"mov-only ABI mmap_request: too many dynamic regions (cap=%d)", mmapMaxRegions))
 		return false
@@ -1054,7 +1090,9 @@ func (r *Runner) handleMmapRequest(call abiCall, regs *regs32) bool {
 			"mmap_request: kernel mapped 0x%x, asked for 0x%x (size=0x%x)", ret, addr, size))
 		return false
 	}
+	r.extraRegionsMu.Lock()
 	r.extraRegions = append(r.extraRegions, struct{ addr, size uint32 }{addr, size})
+	r.extraRegionsMu.Unlock()
 
 	regs.Eip += uint32(call.insnLen)
 	if err := ptraceSetRegs32(r.pid, regs); err != nil {

--- a/turbo86/runner/runner.go
+++ b/turbo86/runner/runner.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"sync"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"github.com/sksat/x86.mov/turbo86/bridge"
@@ -398,6 +399,14 @@ type Runner struct {
 	done      chan struct{}
 	closeOnce sync.Once
 
+	// tickerStop is closed by the tracer goroutine's defer as the
+	// very first step of teardown, *before* it closes eventsCh. The
+	// MemUpdate ticker (if running) watches this channel and exits
+	// without sending — otherwise a tick fired between syscallLoop
+	// returning and the ticker noticing closeCh would panic with
+	// "send on closed channel". Created in `New`.
+	tickerStop chan struct{}
+
 	// Mode-dependent state, populated when the syscall loop starts.
 	mode       proto.Mode       // host (default) or trap
 	handlers   map[uint8]uint32 // signum → handler addr (trap mode only)
@@ -410,14 +419,20 @@ type Runner struct {
 	// pre-declare every region; the Pause / Fault snapshot stays
 	// accurate. Only touched from the tracer goroutine.
 	extraRegions []struct{ addr, size uint32 }
+
+	// (No periodic-snapshot flags — the MemUpdate ticker reads
+	// /proc/PID/mem from a separate goroutine without stopping the
+	// tracee, so it doesn't interact with the tracer's signal-stop
+	// machinery. Pause()'s SIGSTOP path is unchanged.)
 }
 
 type startMsg struct {
-	withCtx  bool
-	entry    uint32
-	stackTop uint32
-	ctx      proto.Context
-	mode     proto.Mode
+	withCtx           bool
+	entry             uint32
+	stackTop          uint32
+	ctx               proto.Context
+	mode              proto.Mode
+	memUpdateInterval time.Duration
 }
 
 // New spawns the stub and drives it to its self-SIGSTOP. The internal
@@ -431,9 +446,10 @@ func New(stubBytes []byte) (*Runner, error) {
 		// consumer reads, so the tracer can't outrun the consumer and
 		// tear down resources (mem fd, child) before mid-session
 		// streaming writes have a chance to land.
-		eventsCh: make(chan proto.Outbound),
-		closeCh:  make(chan struct{}),
-		done:     make(chan struct{}),
+		eventsCh:   make(chan proto.Outbound),
+		closeCh:    make(chan struct{}),
+		done:       make(chan struct{}),
+		tickerStop: make(chan struct{}),
 	}
 
 	bootErr := make(chan error, 1)
@@ -480,6 +496,36 @@ func (r *Runner) RunWithContext(ctx proto.Context) <-chan proto.Outbound {
 // RunWithContextAndMode is RunWithContext with explicit mode selection.
 func (r *Runner) RunWithContextAndMode(ctx proto.Context, mode proto.Mode) <-chan proto.Outbound {
 	r.startCh <- startMsg{withCtx: true, ctx: ctx, mode: mode}
+	return r.eventsCh
+}
+
+// RunWithModeAndMemUpdate is RunWithMode plus periodic MemUpdate
+// Outbound events. `memUpdateInterval` controls the cadence: zero
+// disables (identical to RunWithMode), values > 0 enable a background
+// goroutine that SIGSTOPs the child every `memUpdateInterval`, the
+// tracer catches the resulting stop, emits a `proto.MemUpdate` with
+// the sparse memory snapshot, and resumes the guest. Typical use:
+// `100 * time.Millisecond` for a browser frontend driving a canvas
+// that wants to show partial decoder output mid-run.
+func (r *Runner) RunWithModeAndMemUpdate(
+	entry, stackTop uint32, mode proto.Mode, memUpdateInterval time.Duration,
+) <-chan proto.Outbound {
+	r.startCh <- startMsg{
+		entry: entry, stackTop: stackTop, mode: mode,
+		memUpdateInterval: memUpdateInterval,
+	}
+	return r.eventsCh
+}
+
+// RunWithContextModeAndMemUpdate is RunWithContextAndMode plus periodic
+// MemUpdate (see RunWithModeAndMemUpdate for the cadence semantics).
+func (r *Runner) RunWithContextModeAndMemUpdate(
+	ctx proto.Context, mode proto.Mode, memUpdateInterval time.Duration,
+) <-chan proto.Outbound {
+	r.startCh <- startMsg{
+		withCtx: true, ctx: ctx, mode: mode,
+		memUpdateInterval: memUpdateInterval,
+	}
 	return r.eventsCh
 }
 
@@ -547,6 +593,11 @@ func (r *Runner) tracerLoop(stubBytes []byte, bootErr chan<- error) {
 	// Single defer covers all exit paths (bootstrap failure, pre-Run
 	// close, post-Run close, natural session end).
 	defer func() {
+		// Signal the periodic MemUpdate ticker (if any) to stop
+		// before we close eventsCh — otherwise a tick fired between
+		// syscallLoop returning and the ticker noticing would panic
+		// with "send on closed channel".
+		close(r.tickerStop)
 		if r.cmd != nil && r.cmd.Process != nil {
 			_ = r.cmd.Process.Kill() // no-op if already dead
 			var ws syscall.WaitStatus
@@ -641,7 +692,58 @@ func (r *Runner) tracerLoop(stubBytes []byte, bootErr chan<- error) {
 		return
 	}
 
+	// Start the periodic MemUpdate ticker, if the caller asked for one.
+	// Stopped by closing `closeCh` (Close()) or the syscallLoop
+	// returning naturally (the loop's defer drains by sending SIGKILL,
+	// which closes the ticker's only effective recipient).
+	if msg.memUpdateInterval > 0 {
+		go r.memUpdateTicker(msg.memUpdateInterval)
+	}
+
 	r.syscallLoop(&regs)
+}
+
+// memUpdateTicker runs alongside the tracer goroutine and emits one
+// `proto.MemUpdate` every `interval`. **No SIGSTOP, no ptrace stop**:
+// the snapshot reads `/proc/PID/mem` from this goroutine while the
+// guest keeps executing. A small amount of tearing is OK — the
+// canvas / progressive-display consumer keeps each frame; the next
+// tick fully overwrites it. The trade-off (vs the SIGSTOP-based
+// design) is consistency: a snapshot taken while the guest is mid-
+// scanline-write may show half a row in the old state and half in
+// the new. For movie86's canvas pane that looks fine.
+//
+// Sends to the shared `eventsCh` are serialised against the tracer
+// goroutine's terminal-event sends by an unbuffered-channel race;
+// since both sides eventually progress, whichever wins delivery
+// first is fine. `Close()` short-circuits via `closeCh`.
+func (r *Runner) memUpdateTicker(interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			regions, err := r.snapshotMemory()
+			if err != nil {
+				// Best-effort: snapshot can fail mid-session if the
+				// guest is reading a page that just got remapped or
+				// /proc/PID/mem hit a transient EAGAIN. Skip the tick
+				// rather than tearing down the whole session.
+				continue
+			}
+			select {
+			case r.eventsCh <- proto.MemUpdate{Regions: regions}:
+			case <-r.closeCh:
+				return
+			case <-r.tickerStop:
+				return
+			}
+		case <-r.closeCh:
+			return
+		case <-r.tickerStop:
+			return
+		}
+	}
 }
 
 func (r *Runner) bootstrap(stubBytes []byte) error {
@@ -1198,7 +1300,19 @@ func (r *Runner) syscallLoop(regs *regs32) {
 				nextSignal = int(sig)
 				continue
 			}
+			// Periodic MemUpdate path: if this SIGSTOP is one we sent
+			// ourselves for a memory snapshot (CAS 1→0 on
+			// snapshotPending), grab the regions, emit MemUpdate, and
+			// resume the guest without delivering the signal. The
+			// alternative — sending Paused here — would terminate the
+			// session, which is the right thing for a user-initiated
+			// Pause but wrong for "tick periodically while still
+			// running". CAS distinguishes ours from a Pause()-sent or
+			// truly external SIGSTOP.
 			// Not forwardable (job-control, etc.) — surface as Paused.
+			// (No special-case for periodic SIGSTOP — that path no
+			// longer exists; the MemUpdate ticker reads memory async
+			// without stopping the tracee.)
 			snap, err := r.capturePausedSnapshot(sig)
 			if err != nil {
 				r.emitFault(fmt.Sprintf("snapshot at non-forwardable signal: %v", err))

--- a/turbo86/runner/runner.go
+++ b/turbo86/runner/runner.go
@@ -676,6 +676,27 @@ func (r *Runner) tracerLoop(stubBytes []byte, bootErr chan<- error) {
 		return
 	}
 	if msg.withCtx {
+		// Reservations come first. They cover address ranges the
+		// guest's mov-only ABI mmap_request handler already mapped
+		// on the sender — invisible in Regions when those pages
+		// were still all-zero at snapshot time (the sparse-region
+		// walk skips zero pages). Without this, the canvas demo's
+		// post-set_video_mode handover SIGSEGVs on its first
+		// pixel write because the FB page was never mapped here.
+		// Regions that overlap a reservation are still safe: their
+		// mmap below re-maps the page (MAP_FIXED, fresh zero) and
+		// the region bytes get written on top — same net result.
+		for _, res := range msg.ctx.Reservations {
+			if regionFitsStaticGuest(res.Addr, res.Size) {
+				continue
+			}
+			if err := r.mmapRegionForLoadContext(res.Addr, res.Size, &regs); err != nil {
+				r.emitFault(fmt.Sprintf(
+					"mmap context reservation 0x%x..0x%x: %v",
+					res.Addr, res.Addr+res.Size, err))
+				return
+			}
+		}
 		for _, region := range msg.ctx.Regions {
 			// Regions outside the stub's static guestRegions
 			// (canvas framebuffers from a wasm snapshot, etc.) need a

--- a/turbo86/server/server.go
+++ b/turbo86/server/server.go
@@ -178,22 +178,32 @@ func handleSession(ctx context.Context, ws *websocket.Conn, slog *sessionLogger)
 			if mode == "" {
 				mode = proto.ModeHost
 			}
-			slog.logf("inbound Start: entry=%#x stack_top=%#x mode=%s",
-				m.Entry, m.StackTop, mode)
-			events = r.RunWithMode(m.Entry, m.StackTop, mode)
+			memUpdateInterval := time.Duration(m.MemUpdateIntervalMs) * time.Millisecond
+			slog.logf("inbound Start: entry=%#x stack_top=%#x mode=%s mem_update=%s",
+				m.Entry, m.StackTop, mode, memUpdateInterval)
+			if memUpdateInterval > 0 {
+				events = r.RunWithModeAndMemUpdate(m.Entry, m.StackTop, mode, memUpdateInterval)
+			} else {
+				events = r.RunWithMode(m.Entry, m.StackTop, mode)
+			}
 		case proto.LoadContext:
 			mode := m.Mode
 			if mode == "" {
 				mode = proto.ModeHost
 			}
+			memUpdateInterval := time.Duration(m.MemUpdateIntervalMs) * time.Millisecond
 			var totalBytes int
 			for _, region := range m.Context.Regions {
 				totalBytes += len(region.Bytes)
 			}
-			slog.logf("inbound LoadContext: mode=%s eip=%#x esp=%#x regions=%d total_bytes=%d",
+			slog.logf("inbound LoadContext: mode=%s eip=%#x esp=%#x regions=%d total_bytes=%d mem_update=%s",
 				mode, m.Context.Regs.Eip, m.Context.Regs.Esp,
-				len(m.Context.Regions), totalBytes)
-			events = r.RunWithContextAndMode(m.Context, mode)
+				len(m.Context.Regions), totalBytes, memUpdateInterval)
+			if memUpdateInterval > 0 {
+				events = r.RunWithContextModeAndMemUpdate(m.Context, mode, memUpdateInterval)
+			} else {
+				events = r.RunWithContextAndMode(m.Context, mode)
+			}
 		case proto.Stop:
 			slog.logf("inbound Stop (pre-run abort)")
 			return nil


### PR DESCRIPTION
## 概要

handover した瞬間以降、turbo86 が走ってる間も **定期的にゲストの memory state を movie86/wasm に共有** する仕組みを足す。これで:

- decoder が何 row 単位で書こうと関係なく
- guest が `set_video_mode` 以外何も特別 ABI を呼ばなくても

**ANY guest の framebuffer が canvas にじわじわ描画される** ように。

[#22](https://github.com/sksat/x86.mov/pull/22) で handover 自体は刺さってたけど、ハンドオフ後はメモリが共有されないので canvas が静止画状態だった、という欠落を埋める。

## 設計の核

**`/proc/PID/mem` を async に読む** — tracee を stop しない。

ptrace で attach してる間は `/proc/PID/mem` 読み取り permission を持っているので、guest を実行中のまま別 goroutine から自由に読める。SIGSTOP / wait4 を介さないので:

- guest 実行はずっと走り続ける ([turbo86 native の ~480 instr/pixel 性能](https://github.com/sksat/x86.mov/pull/40) は維持)
- handover の瞬間 (LoadContext / Pause / Fault / Exit) だけ従来通り完全停止 + full snapshot
- 「停止はあんまりしたくない、ハンドオーバーの瞬間だけ全共有でよい」要件にちゃんと合う

メモリ更新中に snapshot を撮るので **若干の tearing** はある (半分新しい / 半分古い row)。progressive display では次の tick で上書きされるのでチラつきは気にならない。

## 変更

### proto

- 新 Outbound: `proto.MemUpdate{Regions []MemRegion}` — `paused.regions` と同形だがセッション継続中の intermediate event
- 新フィールド: `proto.Start.MemUpdateIntervalMs` / `proto.LoadContext.MemUpdateIntervalMs` — opt-in cadence (0 = disabled)
- proto round-trip test に MemUpdate + フィールドを追加

### runner

- `RunWithModeAndMemUpdate` / `RunWithContextModeAndMemUpdate` を追加。`interval > 0` で `memUpdateTicker` goroutine を内部 spawn
- `memUpdateTicker` は interval ごとに `snapshotMemory` → `proto.MemUpdate` を eventsCh に送る
- `tickerStop` channel を新設して deadlock 回避 (tracer の defer で close、ticker は `<-closeCh` / `<-tickerStop` の両方で select)
- 既存 Pause (SIGSTOP → terminal Paused) と periodic 路は signal を共有しないので race なし

### runner tests

- `TestRunner_MemUpdateTicker_EmitsMidRun` — `jmp $` の no-syscall tight loop で 50ms cadence × ≥ 2 個 MemUpdate が出ること
- `TestRunner_MemUpdateZeroInterval_NoMemUpdate` — interval=0 で従来動作 (MemUpdate 出ない)
- `TestRunner_MemUpdateAndPauseCoexist` — periodic 中に Pause() を呼んでも最終的に Paused (terminal) が届く

### server

- `Start.MemUpdateIntervalMs` / `LoadContext.MemUpdateIntervalMs` を `time.Duration` に変換して `RunWith…MemUpdate` 系メソッドに分岐ディスパッチ
- log に `mem_update=Xms` を載せて operator が opt-in 状況を確認できる

### wasm Vm

- `Vm::writeMem(addr, bytes) -> u32` を追加。範囲外 byte は silent skip、書けた byte 数を返す
- turbo86 の stack region (`0x70000000+`) みたいに wasm Vm の mapped range 外でも crash しない設計

### movie86.mjs

- `parseOutboundMessage` に `'mem_update'` ケースを追加
- 同時に `'video_mode'` ケースも追加 (前 PR で wire には流れていたが parse 側が未対応だった)
- `makeLoadContextMessage(ctx, mode, memUpdateIntervalMs)` の 3 引数目を追加 (0 でフィールド送らない、wire 互換)

### demo UI (index.html)

- `ws.onmessage` で `'mem_update'` → `state.vm.writeMem(addr, bytes)` を region 数だけ apply
- `'video_mode'` も同様に `vm.writeMem(0x1FFE_0010, ...)` で `activeVideoMode` を引き起こす → canvas pane が正しい mode に切り替わる
- handover の `LoadContext` 送信時に既存の `refresh` インプット (UI redraw cadence) を `mem_update_interval_ms` として turbo86 に渡す
- symmetry: 「UI が描画する間隔」=「memory が共有される間隔」、ユーザー 1 つのノブ

## supersede している issues

- [#44 (progress_tick mov-only ABI)](https://github.com/sksat/x86.mov/issues/44) — async snapshot は guest cooperation を要らないので、ABI slot を増やさずに「ANY guest が progressive」になる。**より一般化された解** なので #44 は本 PR が刺さったら close
- [#46 (canvas-pinned BMP variant)](https://github.com/sksat/x86.mov/issues/46) — decoder 側で section pinning しなくても async snapshot が canvas を更新するので不要に。canonical な小サイズの BMP fixture でも全画面に「じわじわ」が見える。本 PR が刺さったら close

## ローカル確認

- `go test ./...` 全 OK (新規 3 ケース含む)
- `node tests/smoke.mjs` 9 ok
- `TURBO86_BIN=… node tests/turbo86_handover.mjs` 6 ok (既存パス、mem_update は opt-in なのでデフォルト互換)
- 手元で `make serve` + turbo86 起動 → `bmp_decode` preset で Send to local turbo86 → canvas が **じわじわ埋まる**動作を目視確認 (要 PR #40 の bmp_decode preset)

## 補足: 性能感

PR #40 の bench で turbo86 native は **480 instr/pixel × FHD = 1-5s** で完走する。100ms cadence の MemUpdate 14-50 回 = JSON+base64 で ~数 MB/sec の transient overhead はあるが、結果としては:

- handover 直後 (1ms): black canvas
- 100ms 後: 最初の MemUpdate → 全 FB region 共有 → canvas に初期状態が出る
- 100ms 〜 完成まで: 100ms ごとに canvas 更新 → 「じわじわ描画」が体感できる
- 完成: Exit Outbound → 静止画完成

FHD だと全 MemUpdate region で ~8 MiB の JSON が流れるので帯域注意 (実際は sparse 化されるので半分以下)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)