### PR TITLE
deploy: cache llvm-mov-llc native + wasm artifacts

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -236,9 +236,17 @@ jobs:
         working-directory: llvm-mov/wasm
         run: make build-wasm-llvm-mov-llc
 
+      # Invoke the staging script directly instead of `make stage-deploy`.
+      # The Makefile target declares `build` as a prerequisite, and `build`
+      # is .PHONY — calling it would re-run the wasm + native llvm-mov-llc
+      # builds even when both caches above hit, defeating the cache gates.
+      # The fzstd-install guard from the Makefile is inlined here so the
+      # script's `node_modules/fzstd/main.js` import still resolves.
       - name: stage llvm-mov/wasm into dist/llvm-mov/
         working-directory: llvm-mov/wasm
-        run: make stage-deploy
+        run: |
+          if [ ! -d node_modules/fzstd ]; then npm install; fi
+          ./scripts/stage-deploy.sh
 
       # ----------------------- explorer side -------------------------------
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -201,11 +201,40 @@ jobs:
         working-directory: llvm-mov/wasm
         run: make build-wasm-clang
 
-      - name: llvm-mov/wasm build (native llvm-mov-llc + wasm driver)
+      # Native llvm-mov-llc is a pure function of the backend sources
+      # (llvm/, tools/) + the CMake/Makefile that drives them. The wasm
+      # build script is excluded from this key because it only affects
+      # the wasm artifact, not this native binary.
+      - name: cache native llvm-mov-llc
+        uses: actions/cache@v5.0.5
+        id: lmw-native-llc-cache
+        with:
+          path: llvm-mov/build/bin/llvm-mov-llc
+          key: llvm-mov-llc-native-${{ runner.os }}-${{ hashFiles('llvm-mov/llvm/**', 'llvm-mov/tools/**', 'llvm-mov/CMakeLists.txt', 'llvm-mov/Makefile') }}-v1
+
+      - name: llvm-mov/wasm build (native llvm-mov-llc)
+        if: steps.lmw-native-llc-cache.outputs.cache-hit != 'true'
         working-directory: llvm-mov/wasm
-        run: |
-          make build-native-llvm-mov-llc
-          make build-wasm-llvm-mov-llc
+        run: make build-native-llvm-mov-llc
+
+      # Wasm llvm-mov-llc is a function of the same backend sources
+      # plus the emcmake link script. The build-wasm-llvm.sh artefacts
+      # it consumes (build/llvm-wasm/lib/cmake/llvm) are already covered
+      # by lmw-build-cache above, so they don't need to be in this key.
+      - name: cache wasm llvm-mov-llc artifact
+        uses: actions/cache@v5.0.5
+        id: lmw-wasm-llc-cache
+        with:
+          path: |
+            llvm-mov/wasm/build/llvm-mov-llc.js
+            llvm-mov/wasm/build/llvm-mov-llc.wasm
+            llvm-mov/wasm/build/package.json
+          key: llvm-mov-llc-wasm-${{ runner.os }}-${{ hashFiles('llvm-mov/llvm/**', 'llvm-mov/tools/**', 'llvm-mov/CMakeLists.txt', 'llvm-mov/wasm/scripts/build-wasm-llvm-mov-llc.sh') }}-v1
+
+      - name: llvm-mov/wasm build (wasm llvm-mov-llc driver)
+        if: steps.lmw-wasm-llc-cache.outputs.cache-hit != 'true'
+        working-directory: llvm-mov/wasm
+        run: make build-wasm-llvm-mov-llc
 
       - name: stage llvm-mov/wasm into dist/llvm-mov/
         working-directory: llvm-mov/wasm


### PR DESCRIPTION
## Summary

Closes #52.

`deploy.yaml` の `llvm-mov/wasm build (native llvm-mov-llc + wasm driver)` ステップは唯一アーティファクトキャッシュがなく、movie86 / turbo86 / movfuscator-wasm 単独 PR でも毎回 ~2m43s 走っていた。`clang.wasm` キャッシュと同じ二層 (`actions/cache@v5.0.5` + `if: cache-hit != 'true'`) を被せて、入力が変わらない PR ではビルドをスキップする。

## キャッシュ構成

| 何 | path | key (`hashFiles(...)`) |
|---|---|---|
| native llvm-mov-llc | `llvm-mov/build/bin/llvm-mov-llc` | `llvm-mov/llvm/**`, `llvm-mov/tools/**`, `llvm-mov/CMakeLists.txt`, `llvm-mov/Makefile` |
| wasm llvm-mov-llc | `llvm-mov/wasm/build/llvm-mov-llc.{js,wasm}` + `package.json` | 上の backend sources + `llvm-mov/wasm/scripts/build-wasm-llvm-mov-llc.sh` |

### キー選択の根拠

- **native**: `make -C llvm-mov build` は `cmake -S . -B build` → `ninja`。出力 `llvm-mov-llc` は `llvm-mov/{llvm,tools}/**` (バックエンド + ドライバ) と CMake/Makefile に閉じる。`llvm-mov/wasm/**` は無関係なので意図的に除外 (wasm 側のいじりで native までキャッシュミスさせない)。
- **wasm**: `scripts/build-wasm-llvm-mov-llc.sh` が emcmake で `../CMakeLists.txt` をリビルドする。入力は同じ backend sources + リンクスクリプト自体。スクリプトが消費する `build/llvm-wasm/lib/cmake/llvm` は既存の `lmw-build-cache` で別カバー済みなのでキーには含めない。
- 注: スクリプトは `package.json` (`{"type":"module"}`) も書く。stage-deploy.sh の `required[]` に含まれるので path に追加。issue で挙げられていた `.wasm.zst` / `.wasm.hash` は `build-wasm-clang.sh` 専用で llvm-mov-llc 側では生成されないため除外した。

### ステップ分割

旧:
- `llvm-mov/wasm build (native llvm-mov-llc + wasm driver)` (1 ステップで両方ビルド)

新:
- `cache native llvm-mov-llc` → `llvm-mov/wasm build (native llvm-mov-llc)` (gated)
- `cache wasm llvm-mov-llc artifact` → `llvm-mov/wasm build (wasm llvm-mov-llc driver)` (gated)

wasm 側のスクリプトは native バイナリに依存しないので、native のみキャッシュヒット → wasm のみリビルド (またはその逆) も成立する。

### 注

- 初回マージ後の deploy は両キャッシュをプライミングする一回限りのコールドビルドになる。
- backend sources を触る PR (llvm-mov の通常開発) は当然キャッシュミスして従来通りリビルド。

## Test plan

- [ ] このブランチへの push で deploy.yaml が走り、両キャッシュが新規 save される (初回 prime)
- [ ] その後 cross-subproject PR を立てて、`Cache restored from key:` がログに出てビルドステップが skip されることを確認
- [ ] llvm-mov 側を触る PR ではキャッシュミスして従来通りビルドが走ること