### PR TITLE
turbo86+wasm: MemUpdate に retired-insn count を載せて handover 後の mov カードを native rate に

### DIFF
--- a/movie86/wasm/index.html
+++ b/movie86/wasm/index.html
@@ -744,17 +744,39 @@ function renderMetaFromLocal() {
 
 function renderMetaFromTurbo86() {
     const s = turbo86.stats;
-    $('m-steps').textContent = fmtCount(s.events);
+    // Prefer the real retired-instruction count (from turbo86's
+    // perf_event_open) over the Outbound event count — the latter
+    // was off by orders of magnitude (a guest running at 10⁸ insn/s
+    // emitted ~10 MemUpdate events/s, making the cards look like
+    // execution slowed a million-fold after handover). Falls back
+    // to event count when perf_event_open was denied by the kernel
+    // (`insns` stays 0), so locked-down environments still see the
+    // cards tick.
+    const haveInsns = s.insns > 0;
+    $('m-steps').textContent = fmtCount(haveInsns ? s.insns : s.events);
 
-    // events/sec sampled over the same 250 ms window as the local
-    // mov-rate so the visual cadence is consistent across engines.
+    // Sample rate over the same 250 ms window as the local mov-rate
+    // so the visual cadence is consistent across engines. The window
+    // anchor tracks whichever counter we're displaying.
     if (turbo86.ws && s.halt == null) {
         const now = performance.now();
-        const dt = now - s.rateSampleAt;
-        if (dt >= 250 && s.rateSampleAt !== 0) {
-            s.lastRate = (s.events - s.rateSampleEvents) / (dt / 1000);
-            s.rateSampleAt = now;
-            s.rateSampleEvents = s.events;
+        if (haveInsns) {
+            const dt = now - s.insnsSampleAt;
+            if (dt >= 250 && s.insnsSampleAt !== 0) {
+                s.lastRate = (s.insns - s.insnsSample) / (dt / 1000);
+                s.insnsSampleAt = now;
+                s.insnsSample = s.insns;
+            } else if (s.insnsSampleAt === 0) {
+                s.insnsSampleAt = now;
+                s.insnsSample = s.insns;
+            }
+        } else {
+            const dt = now - s.rateSampleAt;
+            if (dt >= 250 && s.rateSampleAt !== 0) {
+                s.lastRate = (s.events - s.rateSampleEvents) / (dt / 1000);
+                s.rateSampleAt = now;
+                s.rateSampleEvents = s.events;
+            }
         }
     }
     $('m-rate').textContent = s.lastRate == null ? '—' : fmtRate(s.lastRate);
@@ -1053,6 +1075,15 @@ function resetT86Stats() {
         endWall: 0,
         rateSampleAt: 0,
         rateSampleEvents: 0,
+        // Retired-instruction count from turbo86's perf_event_open on
+        // the guest PID, refreshed on each MemUpdate. `insns` is the
+        // latest sample; `insnsSample` / `insnsSampleAt` anchor the
+        // 250 ms rate window. Stays 0 (and the rate stays at the
+        // event-rate fallback) when the kernel denied perf_event_open
+        // so the cards keep moving on a paranoid kernel too.
+        insns: 0,
+        insnsSample: 0,
+        insnsSampleAt: 0,
         lastRate: null,
         halt: null,
         exit: null,
@@ -1269,6 +1300,15 @@ async function doSendToTurbo86() {
                     applied += state.vm.writeMem(r.addr, r.bytes);
                 }
                 turbo86.stats.lastMemUpdateBytes = applied;
+                // Record the cumulative retired-instruction count
+                // turbo86 sampled via perf_event_open on this tick.
+                // `renderMetaFromTurbo86` prefers `insns` over `events`
+                // when it's non-zero, so the cards show native
+                // execution rate instead of the off-by-orders-of-
+                // magnitude event-stand-in.
+                if (msg.insns > 0) {
+                    turbo86.stats.insns = msg.insns;
+                }
                 break;
             }
         }

--- a/movie86/wasm/movie86.mjs
+++ b/movie86/wasm/movie86.mjs
@@ -362,12 +362,16 @@ export function parseOutboundMessage(data) {
             // but no regs/signal/reason. Frontend applies the regions to
             // its local Vm via `vm.writeMem`, so the canvas pane keeps
             // up with the in-flight guest without waiting for terminal
-            // Paused / Exit.
+            // Paused / Exit. `insns` is the cumulative retired-instruction
+            // count from turbo86's perf_event_open on the guest PID;
+            // 0 when the kernel denied the counter. Frontend uses it
+            // to drive the `total mov / mov per sec` cards with native
+            // instruction rate instead of Outbound event count.
             const regions = (m.regions ?? []).map(r => ({
                 addr: r.addr,
                 bytes: base64ToBytes(r.bytes),
             }));
-            return { type: 'mem_update', regions };
+            return { type: 'mem_update', regions, insns: m.insns ?? 0 };
         }
         default:
             throw new Error(`unknown turbo86 outbound type ${JSON.stringify(m.type)}`);

--- a/movie86/wasm/tests/turbo86_handover.mjs
+++ b/movie86/wasm/tests/turbo86_handover.mjs
@@ -477,7 +477,35 @@ async function main() {
             } finally {
                 vm.free();
             }
-            console.log(`ok  real turbo86 handover (MemUpdate ×${memUpdates.length} → writeMem applies bytes)`);
+
+            // Insns field check: turbo86 samples
+            // perf_event_open(PERF_COUNT_HW_INSTRUCTIONS) on each
+            // tick and embeds the cumulative count in MemUpdate.
+            // jmp-self retires the same instruction over and over so
+            // the counter should march forward steadily. Soft-skip
+            // the actual assertion when the kernel denied the counter
+            // (`insns: 0` on every event) — locked-down CI / paranoid
+            // sandboxes default to perf_event_paranoid=3 which
+            // refuses unprivileged perf_event_open, and the runtime
+            // path is already designed to fall back to "frontend
+            // shows event count" there.
+            const nonZero = memUpdates.filter(u => u.insns > 0);
+            if (nonZero.length === 0) {
+                console.log(`skip MemUpdate.insns assertion: perf_event_open unavailable (paranoid kernel?)`);
+            } else {
+                assert.ok(nonZero.length >= 2,
+                    `expected ≥2 MemUpdates with insns>0, got ${nonZero.length}/${memUpdates.length}`);
+                // Counts must be monotonically non-decreasing for a
+                // tight loop. (Equal would only happen if perf gave us
+                // the same sample twice — fine; strictly less is a bug.)
+                for (let i = 1; i < nonZero.length; i++) {
+                    assert.ok(nonZero[i].insns >= nonZero[i - 1].insns,
+                        `MemUpdate.insns went backwards: ${nonZero[i - 1].insns} → ${nonZero[i].insns}`);
+                }
+                assert.ok(nonZero[nonZero.length - 1].insns > nonZero[0].insns,
+                    `MemUpdate.insns did not advance across ${nonZero.length} ticks (final=${nonZero[nonZero.length - 1].insns} initial=${nonZero[0].insns}) — perf counter stuck?`);
+            }
+            console.log(`ok  real turbo86 handover (MemUpdate ×${memUpdates.length} → writeMem applies bytes + insns ${nonZero.length > 0 ? '✓' : 'unavailable'})`);
         } catch (e) {
             console.error(`FAIL MemUpdate E2E: ${e.stack || e.message}`);
             failed++;

--- a/turbo86/proto/proto.go
+++ b/turbo86/proto/proto.go
@@ -317,8 +317,20 @@ func (VideoMode) outboundKind() string { return "video_mode" }
 // non-zero pages, emits one MemUpdate, and resumes. The guest never
 // sees the stop — `SIGSTOP` is non-forwardable and the snapshot path
 // doesn't dispatch into the guest's signal table.
+//
+// Insns is the cumulative retired-instruction count for the guest
+// process up to the snapshot point, sampled from a
+// `perf_event_open(PERF_COUNT_HW_INSTRUCTIONS)` fd opened on the
+// child at spawn time. 0 means "counter unavailable" — the runner
+// emits 0 when the perf counter never opened (e.g. tight kernel
+// `perf_event_paranoid` setting or unprivileged container) so the
+// field is always present but optionally meaningful. The frontend
+// uses this to display real native instruction counts instead of
+// substituting Outbound event counts (which were off by orders of
+// magnitude — a guest running at 10⁸ insn/s emitted ~10 events/s).
 type MemUpdate struct {
 	Regions []MemRegion `json:"regions"`
+	Insns   uint64      `json:"insns,omitempty"`
 }
 
 func (MemUpdate) outboundKind() string { return "mem_update" }

--- a/turbo86/proto/proto_test.go
+++ b/turbo86/proto/proto_test.go
@@ -152,6 +152,20 @@ func TestOutboundRoundTrip(t *testing.T) {
 				{Addr: 0x000B_0000, Bytes: []byte{0x05, 0x06}},
 			}},
 		},
+		{
+			// MemUpdate carries a retired-instruction count sampled
+			// from perf_event_open on the guest PID. Frontend uses
+			// this for the `total mov / mov per sec` cards instead
+			// of substituting Outbound event count (which was off by
+			// orders of magnitude).
+			"MemUpdate with insn count",
+			MemUpdate{
+				Regions: []MemRegion{
+					{Addr: 0x000A_0000, Bytes: []byte{0xff, 0x00, 0x00, 0xff}},
+				},
+				Insns: 12_345_678,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/turbo86/runner/memupdate_test.go
+++ b/turbo86/runner/memupdate_test.go
@@ -4,6 +4,7 @@ package runner
 
 import (
 	"runtime"
+	"syscall"
 	"testing"
 	"time"
 
@@ -76,6 +77,94 @@ loop_events:
 
 	if got < want {
 		t.Errorf("got %d MemUpdate events in 2s, want ≥ %d", got, want)
+	}
+}
+
+// TestRunner_MemUpdateTicker_InsnsAdvances pins that MemUpdate carries
+// a retired-instruction count from perf_event_open and that the count
+// actually grows between consecutive ticks for a guest in a tight
+// `jmp $` loop (which retires the same insn over and over but the
+// counter doesn't care — every retirement bumps it). Without this,
+// the frontend's `total mov / mov per sec` cards would silently stay
+// at the previously-substituted Outbound event count.
+//
+// Soft-skips when `perf_event_open` is denied (locked-down kernel /
+// container) — the runtime fallback path emits Insns=0 by design, but
+// asserting "first MemUpdate has Insns=0" would tell us nothing useful
+// in that environment.
+func TestRunner_MemUpdateTicker_InsnsAdvances(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Pre-flight: open a counter on our own PID to see if the kernel
+	// even allows perf_event_open here. If not, skip — the runtime
+	// path is already covered by the soft-degrade in `bootstrap`, and
+	// asserting Insns=0 doesn't pin meaningful behaviour.
+	if fd, err := openInsnCounter(0); err != nil {
+		t.Skipf("perf_event_open unavailable in this environment: %v", err)
+	} else {
+		_ = syscall.Close(fd)
+	}
+
+	const entry uint32 = 0x08048000
+	loop := []byte{0xEB, 0xFE} // jmp short -2
+
+	r, err := New(stub.Bytes)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if r.perfFd == -1 {
+		_ = r.Close()
+		t.Skip("perf_event_open denied for child PID — same kernel policy")
+	}
+	if err := r.WriteCode(entry, loop); err != nil {
+		_ = r.Close()
+		t.Fatalf("WriteCode: %v", err)
+	}
+
+	events := r.RunWithModeAndMemUpdate(
+		entry, 0x701FFFF0, proto.ModeHost, 50*time.Millisecond,
+	)
+
+	// Need two MemUpdates to compare counts.
+	var first, second uint64
+	deadline := time.After(2 * time.Second)
+loop_events:
+	for {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				t.Fatalf("events channel closed before 2 MemUpdates")
+			}
+			mu, isMemUpdate := ev.(proto.MemUpdate)
+			if !isMemUpdate {
+				continue
+			}
+			if first == 0 {
+				first = mu.Insns
+			} else {
+				second = mu.Insns
+				break loop_events
+			}
+		case <-deadline:
+			break loop_events
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for range events {
+		}
+		close(done)
+	}()
+	_ = r.Close()
+	<-done
+
+	if first == 0 {
+		t.Fatalf("first MemUpdate.Insns = 0; expected the perf counter to be non-zero by the first 50ms tick")
+	}
+	if second <= first {
+		t.Errorf("MemUpdate.Insns did not advance between ticks: first=%d second=%d (jmp-self should keep retiring)", first, second)
 	}
 }
 

--- a/turbo86/runner/perf.go
+++ b/turbo86/runner/perf.go
@@ -1,0 +1,125 @@
+//go:build linux
+
+package runner
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// perf_event_open-driven retired-instruction counter for the guest
+// child. Used by `memUpdateTicker` to embed an actual hardware
+// instruction count in each `proto.MemUpdate`, so the frontend's
+// `total mov / mov per sec` cards reflect native execution rate
+// instead of the previously-substituted Outbound event count (which
+// was off by orders of magnitude — a guest running at 10⁸ insn/s
+// emitted ~10 events/s, making the cards look like the guest had
+// slowed down a million-fold after handover).
+//
+// We hand-write the syscall + struct rather than pulling in
+// `golang.org/x/sys/unix` for this single use: keeps `turbo86`'s
+// dependency surface to just `coder/websocket`, and the perf ABI is
+// stable enough across kernel versions that we don't need the helper.
+// See `man 2 perf_event_open` for the wire format.
+
+// sysPerfEventOpen is the syscall number on x86_64. (turbo86 runs as a
+// 64-bit tracer of a 32-bit guest; the syscall is invoked from the
+// tracer, so the 64-bit number is what we need.)
+const sysPerfEventOpen = 298
+
+// perf_event constants we use. Names mirror `<linux/perf_event.h>`.
+const (
+	perfTypeHardware         = 0
+	perfCountHwInstructions  = 1
+	perfAttrSizeVer3  uint32 = 96
+)
+
+// Bit positions inside the packed `bits` field of perf_event_attr.
+// Only the few we actually set are spelled out.
+const (
+	perfBitDisabled      uint64 = 1 << 0
+	perfBitExcludeKernel uint64 = 1 << 5
+	perfBitExcludeHv     uint64 = 1 << 6
+)
+
+// perfEventAttr mirrors the kernel's `struct perf_event_attr` up to
+// `aux_watermark` (version 3, size 96). The kernel reads min(attr.size,
+// kernel-known size) bytes, so a v3-sized declaration is forward-
+// compatible with newer kernels and accepted by every kernel since 3.14.
+//
+// Field order and types must match the C struct byte-for-byte; only the
+// fields we read or write are individually meaningful, the rest are
+// zeroed and the kernel ignores them for our (HW counter, no sample,
+// no mmap) use.
+type perfEventAttr struct {
+	Type         uint32
+	Size         uint32
+	Config       uint64
+	SamplePeriod uint64
+	SampleType   uint64
+	ReadFormat   uint64
+	Bits         uint64
+	WakeupEvents uint32
+	BpType       uint32
+	BpAddr       uint64
+	BpLen        uint64
+	BranchSample uint64
+	SampleRegsU  uint64
+	SampleStackU uint32
+	ClockId      int32
+	SampleRegsI  uint64
+	AuxWatermark uint32
+	SampleMaxStk uint16
+	_            uint16
+}
+
+// openInsnCounter opens a hardware retired-instruction counter on the
+// given pid. cpu = -1 (count on whatever CPU the task is running on),
+// group_fd = -1 (no group), flags = 0. Counter is created in the
+// "enabled" state so the moment we PtraceCont the child it starts
+// accumulating.
+//
+// Returns -1 + a sentinel error when perf_event_open isn't allowed
+// (e.g. `kernel.perf_event_paranoid` > 2 in unprivileged containers).
+// Callers should treat that as "counter unavailable" and emit Insns=0
+// on the wire rather than failing the session — the demo still works,
+// the frontend just sees no number movement.
+func openInsnCounter(pid int) (int, error) {
+	attr := perfEventAttr{
+		Type:   perfTypeHardware,
+		Size:   perfAttrSizeVer3,
+		Config: perfCountHwInstructions,
+		Bits:   perfBitExcludeKernel | perfBitExcludeHv,
+	}
+	fd, _, errno := syscall.Syscall6(
+		sysPerfEventOpen,
+		uintptr(unsafe.Pointer(&attr)),
+		uintptr(pid),
+		^uintptr(0), // cpu = -1
+		^uintptr(0), // group_fd = -1
+		0,           // flags
+		0,
+	)
+	if errno != 0 {
+		return -1, os.NewSyscallError("perf_event_open", errno)
+	}
+	return int(fd), nil
+}
+
+// readInsnCount returns the cumulative counter value. Reads exactly
+// 8 bytes (a single uint64) — the default ReadFormat layout for a
+// non-group counter without time-enabled / time-running fields.
+func readInsnCount(fd int) (uint64, error) {
+	var buf [8]byte
+	n, err := syscall.Read(fd, buf[:])
+	if err != nil {
+		return 0, fmt.Errorf("read perf counter fd=%d: %w", fd, err)
+	}
+	if n != 8 {
+		return 0, fmt.Errorf("short read on perf counter fd=%d: got %d bytes", fd, n)
+	}
+	return binary.LittleEndian.Uint64(buf[:]), nil
+}

--- a/turbo86/runner/perf.go
+++ b/turbo86/runner/perf.go
@@ -32,9 +32,9 @@ const sysPerfEventOpen = 298
 
 // perf_event constants we use. Names mirror `<linux/perf_event.h>`.
 const (
-	perfTypeHardware         = 0
-	perfCountHwInstructions  = 1
-	perfAttrSizeVer3  uint32 = 96
+	perfTypeHardware               = 0
+	perfCountHwInstructions        = 1
+	perfAttrSizeVer3        uint32 = 96
 )
 
 // Bit positions inside the packed `bits` field of perf_event_attr.

--- a/turbo86/runner/runner.go
+++ b/turbo86/runner/runner.go
@@ -402,6 +402,14 @@ type Runner struct {
 	pid int
 	mem *procMem
 
+	// perfFd is the perf_event_open file descriptor counting retired
+	// instructions on the child. -1 when the kernel rejected the open
+	// (typical on locked-down containers with
+	// `kernel.perf_event_paranoid > 2`). The MemUpdate ticker treats
+	// -1 as "counter unavailable" and emits Insns=0 so the field is
+	// always present on the wire but optionally meaningful.
+	perfFd int
+
 	startCh   chan startMsg
 	eventsCh  chan proto.Outbound
 	closeCh   chan struct{}
@@ -470,6 +478,7 @@ func New(stubBytes []byte) (*Runner, error) {
 		closeCh:    make(chan struct{}),
 		done:       make(chan struct{}),
 		tickerStop: make(chan struct{}),
+		perfFd:     -1,
 	}
 
 	bootErr := make(chan error, 1)
@@ -630,6 +639,9 @@ func (r *Runner) tracerLoop(stubBytes []byte, bootErr chan<- error) {
 		if r.mem != nil {
 			_ = r.mem.f.Close()
 		}
+		if r.perfFd != -1 {
+			_ = syscall.Close(r.perfFd)
+		}
 		close(r.eventsCh)
 		close(r.done)
 	}()
@@ -780,8 +792,18 @@ func (r *Runner) memUpdateTicker(interval time.Duration) {
 				// rather than tearing down the whole session.
 				continue
 			}
+			// Sample the retired-insn counter best-effort; a transient
+			// read failure (or a perfFd that never opened) just yields
+			// 0 here so the frontend sees a frozen-ish counter for
+			// that tick instead of dropping the whole MemUpdate.
+			var insns uint64
+			if r.perfFd != -1 {
+				if n, perfErr := readInsnCount(r.perfFd); perfErr == nil {
+					insns = n
+				}
+			}
 			select {
-			case r.eventsCh <- proto.MemUpdate{Regions: regions}:
+			case r.eventsCh <- proto.MemUpdate{Regions: regions, Insns: insns}:
 			case <-r.closeCh:
 				return
 			case <-r.tickerStop:
@@ -856,6 +878,16 @@ func (r *Runner) bootstrap(stubBytes []byte) error {
 		return fmt.Errorf("open /proc/%d/mem: %w", r.pid, err)
 	}
 	r.mem = &procMem{f: memFile}
+
+	// Open a perf_event_open retired-instruction counter on the child
+	// so MemUpdate can carry a native instruction count. Soft-fail:
+	// when the kernel rejects (e.g. `perf_event_paranoid > 2` in a
+	// locked-down container), `r.perfFd` stays -1 and the ticker
+	// emits Insns=0. We don't bubble the error up — the session
+	// should run without the counter, just with worse-looking cards.
+	if fd, perfErr := openInsnCounter(r.pid); perfErr == nil {
+		r.perfFd = fd
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

PR #51 の "conceptual stretch" 解消。ハンドオーバー後、frontend の \`total mov\` / \`mov per sec\` カードが turbo86 の Outbound event 数 (~10 event/s) を mov 数の代替として表示していて、実際の native 実行レート (~10⁸ insn/s) と万単位でズレていた問題を直す。

turbo86 が \`perf_event_open(PERF_TYPE_HARDWARE, PERF_COUNT_HW_INSTRUCTIONS)\` を child PID に attach、MemUpdate ticker ごとに counter を read して \`proto.MemUpdate.Insns\` に embed。frontend は \`insns > 0\` なら native instruction count をそのまま表示する。

## 変更レイヤ

- **proto**: \`MemUpdate.Insns uint64 omitempty\` + round-trip test ([proto_test.go](turbo86/proto/proto_test.go))
- **runner**: \`golang.org/x/sys/unix\` を引かずに自前で \`perf_event_open\` syscall 実装 ([turbo86/runner/perf.go](turbo86/runner/perf.go))。bootstrap で open、ticker tick で read、teardown で close
- **runner test**: \`TestRunner_MemUpdateTicker_InsnsAdvances\` で jmp-self loop の counter 増加を assert、perf 不通環境では skip
- **movie86.mjs**: \`parseOutboundMessage\` の mem_update case で \`insns\` を返す
- **index.html**: \`renderMetaFromTurbo86\` が \`s.insns > 0\` のとき native insn 数で描画、0 のときは従来の event 数 fallback (locked-down kernel 用)
- **E2E**: MemUpdate.Insns の monotonic 増加を実 turbo86 経由で assert

## Fallback

\`kernel.perf_event_paranoid > 2\` で perf 拒否された場合 (CI sandbox など)、\`r.perfFd = -1\` のまま Insns=0 で emit。frontend は event 数 fallback でカードを更新するので、機能は劣化するが壊れない。

## Test plan

- [x] \`go test ./...\` (turbo86)
- [x] \`node tests/smoke.mjs\` (movie86/wasm)
- [x] \`node tests/turbo86_handover.mjs\` (実 turbo86 E2E、perf 不通環境では Insns assertion を skip)
- [x] \`cargo fmt --check\` + \`cargo clippy -D warnings\` + \`go vet\`
- [ ] preview deploy で実機 perf_event_paranoid≤2 の環境でハンドオーバーして、カード値が妥当 (~10⁸ オーダー) になることを目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)