### PR TITLE
llvm-mov: build out of the box on distros shipping LLVM as a monolithic dylib (Arch)

### DIFF
--- a/llvm-mov/Makefile
+++ b/llvm-mov/Makefile
@@ -2,7 +2,18 @@
 # Mirrors the make-driven convention used by sibling subproject movfuscator-wasm.
 
 LLVM_VERSION ?= 22
-LLVM_CONFIG  ?= llvm-config-$(LLVM_VERSION)
+# Prefer the version-tagged binary (Debian / apt.llvm.org). Fall back to a bare
+# `llvm-config` when its major version matches — distros like Arch ship LLVM
+# unversioned. If neither fits we keep the version-tagged name so `configure`
+# still fails loudly with the install hint.
+LLVM_CONFIG  ?= $(shell \
+	if command -v llvm-config-$(LLVM_VERSION) >/dev/null 2>&1; then \
+		echo llvm-config-$(LLVM_VERSION); \
+	elif [ "$$(llvm-config --version 2>/dev/null | cut -d. -f1)" = "$(LLVM_VERSION)" ]; then \
+		echo llvm-config; \
+	else \
+		echo llvm-config-$(LLVM_VERSION); \
+	fi)
 BUILD_DIR    ?= build
 BUILD_TYPE   ?= Release
 
@@ -48,9 +59,10 @@ help:
 # Surface the missing-llvm-config diagnostic before invoking cmake at all.
 configure:
 	@if [ -z "$(LLVM_CMAKE_DIR)" ]; then \
-		echo "error: $(LLVM_CONFIG) not found. Install LLVM $(LLVM_VERSION) from apt.llvm.org:" 1>&2; \
-		echo "  wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- $(LLVM_VERSION)" 1>&2; \
-		echo "  sudo apt-get install -y llvm-$(LLVM_VERSION)-dev clang-$(LLVM_VERSION) lld-$(LLVM_VERSION) ninja-build" 1>&2; \
+		echo "error: no usable llvm-config for LLVM $(LLVM_VERSION) (tried llvm-config-$(LLVM_VERSION) and a bare llvm-config)." 1>&2; \
+		echo "  Debian/Ubuntu: wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- $(LLVM_VERSION)" 1>&2; \
+		echo "                 sudo apt-get install -y llvm-$(LLVM_VERSION)-dev clang-$(LLVM_VERSION) lld-$(LLVM_VERSION) ninja-build" 1>&2; \
+		echo "  Arch:          sudo pacman -S llvm clang lld cmake ninja  (ships LLVM $(LLVM_VERSION) as a monolithic libLLVM.so)" 1>&2; \
 		exit 1; \
 	fi
 	cmake -S . -B $(BUILD_DIR) -G Ninja \

--- a/llvm-mov/README.md
+++ b/llvm-mov/README.md
@@ -112,6 +112,20 @@ sudo apt-get install -y \
     gcc-multilib libc6-dev-i386
 ```
 
+On Arch the distro `llvm` package already tracks 22.1.x, so no extra repo is
+needed:
+
+```sh
+sudo pacman -S --needed llvm clang lld cmake ninja
+rustup target add i686-unknown-linux-gnu   # only for `make test-rust-example`
+```
+
+Arch ships LLVM unversioned (bare `llvm-config`) and as a single monolithic
+`libLLVM.so` rather than per-component static archives. The `Makefile` picks up
+the unversioned `llvm-config` automatically and the build links the monolithic
+dylib when LLVM was configured with `LLVM_LINK_LLVM_DYLIB` — `make build` works
+without overrides.
+
 Why LLVM 22: bumping in lockstep with upstream is cheap *before* the backend
 has shape; pinning early would just lock us behind. Once the codegen surface
 stabilises we will pin to a specific `22.1.<patch>`.

--- a/llvm-mov/tools/llvm-mov-llc/CMakeLists.txt
+++ b/llvm-mov/tools/llvm-mov-llc/CMakeLists.txt
@@ -14,17 +14,26 @@ target_link_libraries(llvm-mov-llc
   LLVMMovInfo
 )
 
-llvm_map_components_to_libnames(LLVM_LIBS
-  AsmPrinter
-  CodeGen
-  Core
-  IRReader
-  MC
-  ScalarOpts
-  SelectionDAG
-  Support
-  Target
-  TransformUtils
-)
+# LLVM ships in two link flavours. apt.llvm.org (Debian/Ubuntu CI) provides
+# per-component static archives (libLLVMCodeGen.a, ...). Arch's `llvm` package
+# ships ONLY the monolithic libLLVM.so and sets LLVM_LINK_LLVM_DYLIB=ON, so the
+# per-component names below don't exist as link targets there. Pick the flavour
+# the installed LLVM actually offers.
+if(LLVM_LINK_LLVM_DYLIB)
+  set(LLVM_LIBS LLVM)
+else()
+  llvm_map_components_to_libnames(LLVM_LIBS
+    AsmPrinter
+    CodeGen
+    Core
+    IRReader
+    MC
+    ScalarOpts
+    SelectionDAG
+    Support
+    Target
+    TransformUtils
+  )
+endif()
 
 target_link_libraries(llvm-mov-llc PRIVATE ${LLVM_LIBS})


### PR DESCRIPTION
## 概要

LLVM 22.1.x を**モノリシックな `libLLVM.so` 1本**で配布するディストロ（Arch など）でも、オーバーライド無しで `llvm-mov` がビルドできるようにする。既存の apt.llvm.org / Debian 経路はそのまま維持する。

## 背景・理由

これまでのビルドは apt.llvm.org のパッケージングを前提にしていた:
- バージョン付きの `llvm-config-22`
- コンポーネント別の静的ライブラリ（`libLLVMCodeGen.a` など）

一方 Arch の `llvm` パッケージは LLVM を **バージョン無し**（素の `llvm-config`）かつ **モノリシックな `libLLVM.so`**（`LLVM_LINK_LLVM_DYLIB=ON`）で配る。このため `make build` が2段階で失敗していた:
1. `llvm-config-22` が無く `configure` がインストール案内を出して終了。
2. `LLVM_CONFIG=llvm-config` を手で指定しても、ドライバの最終リンクで `cannot find -lLLVMCodeGen`（コンポーネント別の `.a` が存在しない。該当コードは `libLLVM.so` の中にある）。

## 変更内容

- **Makefile** — `llvm-config-$(LLVM_VERSION)` が無く、素の `llvm-config` のメジャーバージョンが一致する場合はそちらへフォールバック。どちらも該当しなければ従来通りバージョン付き名を残し、`configure` が明示的にエラーを出すようにする。インストール案内に Arch 用の行を追加。
- **tools/llvm-mov-llc/CMakeLists.txt** — `LLVM_LINK_LLVM_DYLIB` が ON のときはモノリシックな `LLVM` インポートターゲットをリンク。静的フレーバー向けには従来の `llvm_map_components_to_libnames` のリストを維持するため、**Debian/CI のリンク形態は不変**。
- **README** — Arch の前提パッケージと、Arch では `make build` がオーバーライド不要であることを明記。

リンク配線のみの変更で、**codegen / 出力は不変**（ゴールデンの変化なし）。

## 検証（Arch / LLVM 22.1.5）

クリーンな作業ツリー、**make のオーバーライド無し**:

- `make build` ✅
- `make test` → `39 mov-only, 0 failed`（実行テスト + codegen + mov-only）✅
- `make test-rust-example` → `9 passed, 0 failed` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)