### PR TITLE
movie86/wasm: make the Follow toggle switch live mid-run

### DIFF
--- a/.github/workflows/movie86-wasm.yaml
+++ b/.github/workflows/movie86-wasm.yaml
@@ -25,6 +25,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
+      # Pure-logic unit test for the interactive Run loop — no wasm/build
+      # needed, so run it first for fast feedback. Pins that the loop
+      # re-reads the Follow toggle each iteration (live mid-run switching).
+      - name: runloop unit test (node, no build)
+        run: node tests/runloop.mjs
+
       # Pin the toolchain like the movie86 workflow does — wasm32 is the
       # only target we actually build for here.
       - name: setup rust (stable + wasm32 target)

--- a/movie86/wasm/CLAUDE.md
+++ b/movie86/wasm/CLAUDE.md
@@ -80,7 +80,9 @@ Both ship today; pick by what you want from the call.
   `vm.regs` / `vm.eip` / `vm.steps` / `vm.haltReason` between batches
   and pulling I/O via `vm.drainStdout` / `vm.drainStderr`. Used by
   the demo's interactive Run / Step / Follow controls — see the
-  follow-vs-batch loop in `index.html` for the two refresh strategies.
+  follow-vs-batch loop in [`runloop.mjs`](runloop.mjs) for the two
+  refresh strategies (`doRun` in `index.html` just wires the DOM
+  controls / Vm into it).
 - **`vm.disasmAt(addr) -> DecodedInsn`** — same `movie86::decode` the
   CPU uses, but exposed so the demo can render a "next-N-instructions"
   pane with the current EIP highlighted. The decoded text is the
@@ -195,9 +197,9 @@ pair brings the session back into the local Vm. Six pieces:
 
 ## Display strategy: follow vs periodic
 
-The demo's "Follow execution" checkbox switches between two loop shapes.
-Both yield to the browser each iteration so the **Stop** button stays
-responsive.
+The demo's "Follow execution" checkbox switches between two display
+strategies. Both yield to the browser each iteration so the **Stop**
+button stays responsive.
 
 - **Follow**: `vm.stepN(1)` + `render()` per loop. One instruction per
   frame. Slow on purpose — for watching individual moves land.
@@ -211,6 +213,19 @@ following all execution state optional. If not following, just dump
 periodically." Don't collapse the two modes into a single render-rate
 slider — they answer different questions ("show me each step" vs
 "keep me roughly informed while it runs hot").
+
+**The two strategies live in ONE loop ([`runloop.mjs`](runloop.mjs)),
+not two `while` shapes chosen up front.** `runLoop` re-reads the controls
+(`follow` / `delay` / `batch` / `refresh`) via the injected
+`readControls()` on *every* iteration, so flipping Follow — or retuning
+the cadence — mid-run takes effect on the next step. The earlier code
+snapshotted `follow` into a `const` at the top of `doRun` and branched
+into one of two loops, which locked the strategy for the whole run; that
+was the "can't toggle Follow while it's running" bug. Keep the
+per-iteration read: it's the seam that makes the toggle live, and
+[`tests/runloop.mjs`](tests/runloop.mjs) (pure-logic, no wasm) pins it.
+The disasm/mem "follow EIP" toggles were already live because they're
+read inside `render()`; this brings the master Follow toggle in line.
 
 ## Things future Claude shouldn't relearn
 

--- a/movie86/wasm/index.html
+++ b/movie86/wasm/index.html
@@ -343,6 +343,7 @@ import {
     makeLoadContextMessage,
     parseOutboundMessage,
 } from './movie86.mjs';
+import { runLoop } from './runloop.mjs';
 
 const $ = (id) => document.getElementById(id);
 
@@ -907,34 +908,27 @@ async function doRun() {
     setEngine('local');
     const myRun = ++state.runId;
     setRunButton(true);
-    const follow = $('follow').checked;
-    const batchSize = BigInt(Math.max(1, Math.floor(Number($('batch').value) || 50000)));
-    const refreshMs = Math.max(0, Math.floor(Number($('refresh').value) || 100));
-    // Follow-mode step delay — sleep this long between steps so the
-    // user can actually watch the highlight move. 0 = as-fast-as-the-
-    // -browser-allows (setTimeout(0) still yields ~4 ms in practice).
-    const delayMs = Math.max(0, Math.floor(Number($('delay').value) || 0));
     const startWall = performance.now();
     try {
-        if (follow) {
-            while (myRun === state.runId && !vm.haltReason) {
-                vm.stepN(1n);
-                render();
-                await new Promise(r => setTimeout(r, delayMs));
-            }
-        } else {
-            let lastRender = performance.now();
-            while (myRun === state.runId && !vm.haltReason) {
-                vm.stepN(batchSize);
-                const now = performance.now();
-                if (now - lastRender >= refreshMs) {
-                    render();
-                    lastRender = now;
-                }
-                await new Promise(r => setTimeout(r, 0));
-            }
-            render();
-        }
+        // The controls are read FRESH each iteration inside runLoop, so
+        // the user can flip Follow / retune delay-batch-refresh mid-run
+        // and have it take effect on the next step. `delayMs` is the
+        // follow-mode step delay (0 = as-fast-as-the-browser-allows;
+        // setTimeout(0) still yields ~4 ms in practice).
+        await runLoop({
+            shouldContinue: () => myRun === state.runId && !vm.haltReason,
+            readControls: () => ({
+                follow: $('follow').checked,
+                delayMs: Math.max(0, Math.floor(Number($('delay').value) || 0)),
+                batchSize: BigInt(Math.max(1, Math.floor(Number($('batch').value) || 50000))),
+                refreshMs: Math.max(0, Math.floor(Number($('refresh').value) || 100)),
+            }),
+            stepOne: () => vm.stepN(1n),
+            stepBatch: (n) => vm.stepN(n),
+            render,
+            sleep: (ms) => new Promise(r => setTimeout(r, ms)),
+            now: () => performance.now(),
+        });
     } finally {
         if (myRun === state.runId) setRunButton(false);
         const wall = Math.round(performance.now() - startWall);

--- a/movie86/wasm/runloop.mjs
+++ b/movie86/wasm/runloop.mjs
@@ -1,0 +1,56 @@
+// The interactive Run loop for the in-browser Vm, extracted from
+// index.html's `doRun` so the follow-vs-batch cadence is unit-testable
+// (see tests/runloop.mjs) without a DOM or the wasm Vm.
+//
+// Why a single loop instead of two: the demo offers two display
+// strategies (see movie86/wasm/CLAUDE.md "Display strategy: follow vs
+// periodic"), and the user must be able to switch between them *while a
+// run is in flight*. The earlier shape picked the strategy once — it
+// read `follow` into a const and branched into one of two `while`
+// loops — so toggling the Follow checkbox mid-run had no effect until
+// the next Run. Here the two strategies live in one loop and the
+// controls are re-read every iteration via `readControls()`, so flipping
+// Follow (or retuning delay / batch / refresh) takes effect on the next
+// step. The two strategies themselves are unchanged and deliberately
+// kept distinct — they answer different questions ("show me each step"
+// vs "keep me roughly informed while it runs hot").
+//
+// All side effects and inputs are injected (`io`):
+//   shouldContinue() -> bool   keep looping? (false on Stop / halt)
+//   readControls()    -> { follow, delayMs, batchSize, refreshMs }
+//                              read FRESH each iteration — this is the
+//                              whole point of the extraction
+//   stepOne()                  advance the Vm by one instruction
+//   stepBatch(batchSize)       advance the Vm by `batchSize` instructions
+//   render()                   repaint the UI from current Vm state
+//   sleep(ms)  -> Promise      yield to the browser so Stop stays live
+//   now()      -> ms           monotonic clock (performance.now)
+export async function runLoop(io) {
+    const { shouldContinue, readControls, stepOne, stepBatch, render, sleep, now } = io;
+    let lastRender = now();
+    while (shouldContinue()) {
+        const { follow, delayMs, batchSize, refreshMs } = readControls();
+        if (follow) {
+            // Follow: one instruction per frame, render every step, sleep
+            // `delayMs` so the user can watch the highlight move.
+            stepOne();
+            render();
+            lastRender = now();
+            await sleep(delayMs);
+        } else {
+            // Periodic dump: batch steps cheaply, render only once every
+            // `refreshMs` so the wasm boundary overhead stays low on a
+            // hot guest. Yield with sleep(0) to keep Stop responsive.
+            stepBatch(batchSize);
+            const t = now();
+            if (t - lastRender >= refreshMs) {
+                render();
+                lastRender = t;
+            }
+            await sleep(0);
+        }
+    }
+    // Flush the final state once the loop ends (halt / Stop / mode tail)
+    // so the last batch's effects are always on screen.
+    render();
+}

--- a/movie86/wasm/scripts/stage-deploy.sh
+++ b/movie86/wasm/scripts/stage-deploy.sh
@@ -16,6 +16,7 @@ sub="$dist/movie86"
 required=(
     "$here/index.html"
     "$here/movie86.mjs"
+    "$here/runloop.mjs"
     "$here/build/browser/movie86_wasm_bg.wasm"
     "$here/build/browser/movie86_wasm.js"
 )
@@ -35,6 +36,7 @@ mkdir -p "$sub/build/browser"
 
 cp "$here/index.html"   "$sub/"
 cp "$here/movie86.mjs"  "$sub/"
+cp "$here/runloop.mjs"  "$sub/"
 
 cp "$here/build/browser/movie86_wasm_bg.wasm" \
    "$here/build/browser/movie86_wasm.js" \

--- a/movie86/wasm/tests/runloop.mjs
+++ b/movie86/wasm/tests/runloop.mjs
@@ -1,0 +1,115 @@
+// Unit tests for the interactive Run loop (`runloop.mjs`).
+//
+// The loop is extracted from index.html's `doRun` precisely so this
+// logic is testable without a DOM or the wasm Vm: every side effect
+// (stepping, rendering, sleeping, reading the clock) and every control
+// input (the Follow toggle + delay / batch / refresh) is injected.
+//
+// The headline behaviour these tests pin — and the bug that motivated
+// the extraction — is that `runLoop` must read the controls FRESH on
+// every iteration. The pre-extraction code snapshotted `follow` once at
+// the top of the run, so flipping the checkbox mid-run did nothing. A
+// passing "live toggle" test below is only possible if the loop polls
+// readControls() each pass.
+//
+// Run standalone: `node tests/runloop.mjs` (no build / wasm needed).
+
+import assert from 'node:assert/strict';
+import { runLoop } from '../runloop.mjs';
+
+let failed = 0;
+async function test(name, fn) {
+    try {
+        await fn();
+        console.log(`ok  ${name}`);
+    } catch (e) {
+        console.error(`FAIL ${name}: ${e.stack || e.message}`);
+        failed++;
+    }
+}
+
+// --- live Follow toggle: the regression this whole change is about ---
+//
+// Start in follow mode (one-step-per-frame), then flip follow off after
+// the second step. The loop must switch to batch stepping immediately,
+// which is only observable if it re-reads the control each iteration.
+await test('reads Follow fresh each iteration (live toggle)', async () => {
+    let i = 0;
+    let follow = true;
+    const seq = [];
+    await runLoop({
+        shouldContinue: () => i < 4,
+        readControls: () => ({ follow, delayMs: 0, batchSize: 100n, refreshMs: 0 }),
+        stepOne: () => { seq.push('one'); i++; if (i === 2) follow = false; },
+        stepBatch: () => { seq.push('batch'); i++; },
+        render: () => {},
+        sleep: async () => {},
+        now: () => 0,
+    });
+    assert.deepEqual(seq, ['one', 'one', 'batch', 'batch']);
+});
+
+// --- follow on: one step + one render per iteration, plus a final render ---
+await test('follow mode steps once and renders every iteration', async () => {
+    let i = 0, ones = 0, renders = 0;
+    await runLoop({
+        shouldContinue: () => i < 3,
+        readControls: () => ({ follow: true, delayMs: 0, batchSize: 1n, refreshMs: 0 }),
+        stepOne: () => { ones++; i++; },
+        stepBatch: () => { throw new Error('stepBatch must not run in follow mode'); },
+        render: () => { renders++; },
+        sleep: async () => {},
+        now: () => 0,
+    });
+    assert.equal(ones, 3);
+    assert.equal(renders, 3 + 1, 'per-iteration renders plus one final render');
+});
+
+// --- follow off: batch stepping with refreshMs-throttled rendering ---
+//
+// `now()` is fed a scripted clock so the throttle is deterministic:
+//   call 1 (pre-loop lastRender) -> 0
+//   iter 1 -> 50   (50-0   <100  : no render)
+//   iter 2 -> 150  (150-0  >=100 : render, lastRender=150)
+//   iter 3 -> 200  (200-150<100  : no render)
+//   iter 4 -> 320  (320-150>=100 : render, lastRender=320)
+// Two in-loop renders + one unconditional final render = 3.
+await test('batch mode throttles render by refreshMs and renders once at the end', async () => {
+    let i = 0, renders = 0;
+    const sizes = [];
+    const clock = [0, 50, 150, 200, 320];
+    let tick = 0;
+    await runLoop({
+        shouldContinue: () => i < 4,
+        readControls: () => ({ follow: false, delayMs: 0, batchSize: 10n, refreshMs: 100 }),
+        stepOne: () => { throw new Error('stepOne must not run in batch mode'); },
+        stepBatch: (n) => { sizes.push(n); i++; },
+        render: () => { renders++; },
+        sleep: async () => {},
+        now: () => clock[tick++],
+    });
+    assert.equal(renders, 3, 'two throttled renders + one final render');
+    assert.deepEqual(sizes, [10n, 10n, 10n, 10n], 'batchSize forwarded to stepBatch');
+});
+
+// --- shouldContinue gates the loop (Stop / halt) ---
+await test('does not step when shouldContinue is false from the start', async () => {
+    let steps = 0, renders = 0;
+    await runLoop({
+        shouldContinue: () => false,
+        readControls: () => ({ follow: true, delayMs: 0, batchSize: 1n, refreshMs: 0 }),
+        stepOne: () => { steps++; },
+        stepBatch: () => { steps++; },
+        render: () => { renders++; },
+        sleep: async () => {},
+        now: () => 0,
+    });
+    assert.equal(steps, 0, 'no stepping when the loop should not run');
+    assert.equal(renders, 1, 'still flushes one final render');
+});
+
+if (failed > 0) {
+    console.error(`${failed} runloop test(s) failed`);
+    process.exit(1);
+}
+console.log('all runloop tests passed');


### PR DESCRIPTION
## What

run 中に「Follow execution」トグルを切り替えても効かなかった問題を修正。run 中にインタラクティブに切り替えられるようにした。

## Why

`doRun` が `$('follow').checked` を冒頭で `const` に一度だけ読み、follow 用 / batch 用の2つの `while` ループのどちらかに入って固定していたため、run 中のチェックボックス変更は次の Run まで反映されなかった。（`disasm-follow` / `mem-follow` は `render()` 内で都度読まれるため元から live、turbo86 ハンドオーバ側も毎イベント読むため live だった — master の Follow だけが取り残されていた。）

## How

実行ループを `movie86/wasm/runloop.mjs` の単一の依存注入関数 `runLoop(io)` に抽出。制御値（follow / delay / batch / refresh）を `readControls()` 経由で**毎イテレーション**読むため、トグルもケイデンス調整も次ステップで反映される。2つの表示戦略（1命令/フレーム vs refreshMs スロットルのバッチ）は維持し区別したまま、「冒頭スナップショット束縛」だけを除去。`index.html` の `doRun` は DOM 操作 / Vm を `runLoop` に配線するだけになった。

## Tests / Verification

- **単体テスト** `tests/runloop.mjs`（純ロジック・wasm 不要）: 毎イテレーションの制御値読み取り、ライブトグル、refreshMs スロットル、最終 render を pin。CI ではビルド不要の fast ステップとして最初に実行。
- **E2E**: ヘッドレス chromium を CDP で駆動し、実 `index.html` + wasm Vm で `cycle.elf` を run しながら ON→OFF→ON を切替。ステップレートが約5000倍変化し低速へ戻ることを確認。
- `stage-deploy.sh` が `runloop.mjs` を配信対象に追加（バンドラ無し構成なので各 `.mjs` はそのまま配信）。

TDD: 失敗するテスト → 抽出実装 → green の順で作成。

🤖 Generated with [Claude Code](https://claude.com/claude-code)