### PR TITLE
turbo86: WS 経由のキー入力 (KeyInput Inbound) を runner 入力キューに配線

### DIFF
--- a/turbo86/proto/proto.go
+++ b/turbo86/proto/proto.go
@@ -166,6 +166,21 @@ type Pause struct{}
 
 func (Pause) inboundKind() string { return "pause" }
 
+// KeyInput delivers one generic input key code to a running guest. The
+// runner enqueues it; the guest reads it via the mov-only CALL_POLL_INPUT
+// ABI (one code per poll, KEY_NONE when the queue is empty). Codes match
+// movie86's KEY_* alphabet (printable ASCII pass through; non-printable
+// keys use the 0x80+ block) — the same byte the local movie86 Vm would
+// see via pushInput, so a deck behaves identically before and after a
+// turbo86 handover. This is what makes native-speed slide advance work:
+// the frontend forwards keydowns over the wire and the guest blits at
+// full native speed instead of crawling through the wasm emulator.
+type KeyInput struct {
+	Code uint8 `json:"code"`
+}
+
+func (KeyInput) inboundKind() string { return "key_input" }
+
 // MarshalInbound encodes an Inbound as a JSON object with a "type" field.
 func MarshalInbound(msg Inbound) ([]byte, error) {
 	switch m := msg.(type) {
@@ -192,6 +207,11 @@ func MarshalInbound(msg Inbound) ([]byte, error) {
 		return json.Marshal(struct {
 			Type string `json:"type"`
 		}{m.inboundKind()})
+	case KeyInput:
+		return json.Marshal(struct {
+			Type string `json:"type"`
+			KeyInput
+		}{m.inboundKind(), m})
 	default:
 		return nil, fmt.Errorf("proto: unknown Inbound type %T", msg)
 	}
@@ -229,6 +249,12 @@ func UnmarshalInbound(data []byte) (Inbound, error) {
 		return Stop{}, nil
 	case "pause":
 		return Pause{}, nil
+	case "key_input":
+		var m KeyInput
+		if err := json.Unmarshal(data, &m); err != nil {
+			return nil, fmt.Errorf("proto: parsing KeyInput payload: %w", err)
+		}
+		return m, nil
 	default:
 		return nil, fmt.Errorf("proto: unknown Inbound type %q", probe.Type)
 	}

--- a/turbo86/proto/proto_test.go
+++ b/turbo86/proto/proto_test.go
@@ -83,6 +83,9 @@ func TestInboundRoundTrip(t *testing.T) {
 		},
 		{"Stop", Stop{}},
 		{"Pause", Pause{}},
+		{"KeyInput Right", KeyInput{Code: 0x81}},
+		{"KeyInput printable", KeyInput{Code: 'a'}},
+		{"KeyInput zero", KeyInput{Code: 0}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/turbo86/runner/abi_test.go
+++ b/turbo86/runner/abi_test.go
@@ -178,6 +178,50 @@ func TestRunOnce_AbiPollInput(t *testing.T) {
 	}
 }
 
+// TestRunOnce_AbiPollInput_ReturnsQueuedKey drives the input *source*:
+// a key code pushed onto the runner before the guest runs must come
+// back from the poll in EAX. This is what makes native-speed slide
+// advance work — the frontend's keydown becomes a proto.KeyInput, the
+// runner queues it, and the guest reads it through the same ABI slot.
+//
+// Guest:
+//
+//	A2 40 00 FE 1F      mov [0x1FFE0040], al  ; poll → EAX = queued key
+//	A3 FE 00 FE 1F      mov [0x1FFE00FE], eax ; exit(EAX)
+func TestRunOnce_AbiPollInput_ReturnsQueuedKey(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	const entry uint32 = 0x08048000
+	const keyRight uint8 = 0x81 // movie86 KEY_RIGHT
+	code := []byte{
+		0xA2, 0x40, 0x00, 0xFE, 0x1F,
+		0xA3, 0xFE, 0x00, 0xFE, 0x1F,
+	}
+
+	r, err := New(stub.Bytes)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer r.Close()
+
+	// Queue the key before the guest starts; the poll must dequeue it.
+	r.PushInput(keyRight)
+
+	ch := r.RunWithContextAndMode(proto.Context{
+		Regs:    proto.Regs{Eip: entry, Esp: testStackTop},
+		Regions: []proto.MemRegion{{Addr: entry, Bytes: code}},
+	}, proto.ModeHost)
+	var events []proto.Outbound
+	for ev := range ch {
+		events = append(events, ev)
+	}
+	want := []proto.Outbound{proto.Exit{Code: int32(keyRight)}}
+	if !reflect.DeepEqual(events, want) {
+		t.Errorf("events:\n  got:  %#v\n  want: %#v", events, want)
+	}
+}
+
 // TestRunOnce_AbiLoadContext_AutoMmapsOutOfRangeRegions verifies that
 // a LoadContext carrying a region OUTSIDE the stub's static guestRegions
 // triggers a dynamic mmap2 before the region's bytes are written via

--- a/turbo86/runner/deck_bench_test.go
+++ b/turbo86/runner/deck_bench_test.go
@@ -1,0 +1,117 @@
+//go:build linux
+
+package runner
+
+import (
+	"debug/elf"
+	"io"
+	"os"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/sksat/x86.mov/turbo86/proto"
+	"github.com/sksat/x86.mov/turbo86/stub"
+)
+
+// TestDeckBench_NativeSpeed runs a SIMD86 bench deck (deck_bench.elf,
+// which exits once it reaches the last slide) natively under turbo86,
+// pre-queues (n-1) Right keys, and reports the wall-clock for
+// "boot + initial blit + (n-1) slide transitions". This is the
+// native-speed counterpart to the movie86 wasm number (~40 s/transition)
+// — the whole point of the turbo86 handover for live presentation.
+//
+// Env-gated (the ELF is ~11 MiB, movfuscator-built, gitignored):
+//
+//	TURBO86_DECK_BENCH=/tmp/deck_bench.elf TURBO86_DECK_SLIDES=4 \
+//	    go test ./runner -run TestDeckBench_NativeSpeed -v
+func TestDeckBench_NativeSpeed(t *testing.T) {
+	elfPath := os.Getenv("TURBO86_DECK_BENCH")
+	if elfPath == "" {
+		t.Skip("set TURBO86_DECK_BENCH=path/to/deck_bench.elf to run")
+	}
+	nSlides := 4
+	if v := os.Getenv("TURBO86_DECK_SLIDES"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			t.Fatalf("bad TURBO86_DECK_SLIDES=%q", v)
+		}
+		nSlides = n
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	f, err := elf.Open(elfPath)
+	if err != nil {
+		t.Fatalf("open ELF: %v", err)
+	}
+	defer f.Close()
+
+	r, err := New(stub.Bytes)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer r.Close()
+
+	for _, p := range f.Progs {
+		if p.Type != elf.PT_LOAD || p.Filesz == 0 {
+			continue
+		}
+		// The framebuffer segment (.fb13h @ ~0xA0000) sits outside the
+		// stub's static guest region; the deck maps it itself at runtime
+		// via mmap_request, exactly as it does in the live handover. Only
+		// pre-load segments that land in the static code/data region.
+		if p.Vaddr < 0x08048000 || p.Vaddr >= 0x09048000 {
+			t.Logf("skip out-of-region segment @ 0x%x (guest mmaps it)", p.Vaddr)
+			continue
+		}
+		buf := make([]byte, p.Filesz)
+		if _, err := io.ReadFull(p.Open(), buf); err != nil {
+			t.Fatalf("read segment @ 0x%x: %v", p.Vaddr, err)
+		}
+		if err := r.WriteCode(uint32(p.Vaddr), buf); err != nil {
+			t.Fatalf("write segment @ 0x%x: %v", p.Vaddr, err)
+		}
+	}
+
+	// Pre-queue (n-1) Right keys so the deck advances straight to the
+	// last slide and exits.
+	const keyRight uint8 = 0x81
+	for i := 0; i < nSlides-1; i++ {
+		r.PushInput(keyRight)
+	}
+
+	start := time.Now()
+	events := r.Run(uint32(f.Entry), 0x701FFFF0)
+
+	var exited bool
+	timeout := time.After(120 * time.Second)
+loop:
+	for {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				break loop
+			}
+			t.Logf("event: %T", ev) // type only — Paused carries MBs of regions
+			if _, isExit := ev.(proto.Exit); isExit {
+				exited = true
+				break loop
+			}
+			if fa, isFault := ev.(proto.Fault); isFault {
+				t.Fatalf("guest faulted: %s", fa.Reason)
+			}
+		case <-timeout:
+			t.Fatalf("deck did not exit within 120s (movfuscator master-loop wall?)")
+		}
+	}
+	elapsed := time.Since(start)
+
+	if !exited {
+		t.Fatalf("events channel closed without Exit")
+	}
+	t.Logf("deck_bench: boot + initial blit + %d transitions in %v (%.1f ms/transition incl. boot)",
+		nSlides-1, elapsed, float64(elapsed.Milliseconds())/float64(nSlides-1))
+}

--- a/turbo86/runner/runner.go
+++ b/turbo86/runner/runner.go
@@ -424,6 +424,15 @@ type Runner struct {
 	done      chan struct{}
 	closeOnce sync.Once
 
+	// inputCh is the runner's input queue feeding the CALL_POLL_INPUT
+	// ABI. The orchestrating goroutine (WS handler) PushInputs key codes
+	// onto it; the tracer goroutine drains one per poll, non-blocking
+	// both ways. Buffered so a burst of keystrokes between polls isn't
+	// lost; a full buffer drops the oldest-unread excess (a held arrow
+	// key spamming faster than the guest polls is the only way to hit
+	// it, and dropping there is the right behaviour — see PushInput).
+	inputCh chan uint8
+
 	// tickerStop is closed by the tracer goroutine's defer to signal
 	// the MemUpdate ticker (if running) to wind down, and tickerWg
 	// is the join handle the defer waits on **before** closing
@@ -497,6 +506,10 @@ func New(stubBytes []byte) (*Runner, error) {
 		done:       make(chan struct{}),
 		tickerStop: make(chan struct{}),
 		perfFd:     -1,
+		// Buffered: keystrokes arrive on the WS goroutine and are drained
+		// on the tracer goroutine at poll time. 256 is plenty for human
+		// input between polls; overflow drops excess (PushInput).
+		inputCh: make(chan uint8, 256),
 	}
 
 	bootErr := make(chan error, 1)
@@ -627,6 +640,34 @@ func (r *Runner) Pause() error {
 		return err
 	}
 	return nil
+}
+
+// PushInput enqueues one generic input key code for the guest to read
+// via the CALL_POLL_INPUT ABI. Safe to call from the orchestrating
+// goroutine (the WS handler) while the tracer goroutine is running —
+// the channel is the synchronisation point.
+//
+// Non-blocking: if the buffer is full (a key held down spamming faster
+// than the guest polls) the code is dropped rather than stalling the WS
+// reader. Dropping is the right call for input — a slideshow that's
+// behind on a held arrow key wants to land on the latest reachable
+// slide, not replay a backlog.
+func (r *Runner) PushInput(code uint8) {
+	select {
+	case r.inputCh <- code:
+	default:
+	}
+}
+
+// popInput returns the next queued key code, or keyNone if the queue is
+// empty. Called only from the tracer goroutine (the poll dispatch).
+func (r *Runner) popInput() uint8 {
+	select {
+	case code := <-r.inputCh:
+		return code
+	default:
+		return keyNone
+	}
 }
 
 // tracerLoop owns the OS thread that did exec.Cmd.Start. All ptrace
@@ -1043,12 +1084,12 @@ func (r *Runner) dispatchAbi(call abiCall, regs *regs32) bool {
 		return r.handleMmapRequest(call, regs)
 	case abiCallPollInput:
 		// Poll for one pending input event. The guest's written value
-		// (the trigger) is ignored; we hand a key code back in EAX, the
-		// same "return through EAX" shape abiCallWrite uses. No input
-		// source is wired yet, so this always reports keyNone — the
-		// EIP-advance + SetRegs at the bottom of the switch writes the
-		// updated EAX back to the guest.
-		regs.Eax = uint32(keyNone)
+		// (the trigger) is ignored; we pop one key code off the input
+		// queue (keyNone if empty) and hand it back in EAX — the same
+		// "return through EAX" shape abiCallWrite uses. Keys arrive from
+		// the frontend over the wire as proto.KeyInput; the EIP-advance
+		// + SetRegs at the bottom of the switch writes EAX back.
+		regs.Eax = uint32(r.popInput())
 	case abiCallWrite:
 		// Mirrors the int 0x80 SYS_write ABI: fd in ebx, buf in ecx,
 		// len in edx. eax (the "value" the guest wrote to trigger the

--- a/turbo86/server/server.go
+++ b/turbo86/server/server.go
@@ -247,6 +247,9 @@ func handleSession(ctx context.Context, ws *websocket.Conn, slog *sessionLogger)
 					readDone <- fmt.Errorf("pause: %w", err)
 					return
 				}
+			case proto.KeyInput:
+				slog.logf("inbound KeyInput: code=%#x", m.Code)
+				r.PushInput(m.Code)
 			default:
 				readDone <- fmt.Errorf("unexpected inbound %T after Start/LoadContext", msg)
 				return


### PR DESCRIPTION
## 概要

#59 で追加した `CALL_POLL_INPUT` は、turbo86 側では入力ソースが繋がっておらず常に `KEY_NONE` を返すだけだった。本 PR はフロントエンドのキー入力を **WebSocket 越しに runner へ届け**、guest の poll が実際のキーコードを受け取れるようにする。

これにより、デックを turbo86 にハンドオーバーすると **ネイティブ速度でスライド遷移**できる。計測では movie86(wasm エミュレータ)の **~40秒/遷移** に対し、turbo86 ネイティブは **~1ms/遷移**(boot + 初期描画 + 3遷移 = 3.46ms)。

> ⚠️ base は #59(`movie86/mov-only-input-abi`)にスタックしています。#59 のマージ後にこの PR を確認してください。

## 変更点

- **proto**: `KeyInput{Code uint8}` Inbound を追加。`MarshalInbound` / `UnmarshalInbound` に `"key_input"` を配線。round-trip テスト3件を追加。
- **runner**: バッファ付き `inputCh` + `PushInput()`(WS goroutine から呼ぶ)/ `popInput()`(tracer goroutine から呼ぶ)。`dispatchAbi` の `CALL_POLL_INPUT` が `popInput()` の結果を EAX に返す。非ブロッキング両方向 — 満杯ならドロップ(押しっぱなしの暴走を吸収)、空なら `keyNone`。ロック不要で tracer ループを止めない。
- **server**: post-start ループで `proto.KeyInput` → `r.PushInput` をルーティング。
- **test**: `runner/abi_test.go` に「事前 push したキーが poll で EAX に返る」テスト(RED→GREEN)。`runner/deck_bench_test.go`(env-gated)で実デックの native 実行速度を計測(`TURBO86_DECK_BENCH` 指定時のみ走り、通常 CI は skip)。

## 補足

- `CALL_POLL_INPUT` の定数・意味は #59 の movie86 側と **byte-for-byte 一致**(cross-engine contract)。
- 純粋 movfuscator 出力を turbo86 でネイティブ実行する件は別途 #60 で追跡(本 PR はキー入力の配線のみ)。
- `go build` / `go vet` / `gofmt` クリーン、turbo86 全スイート green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)