### PR TITLE
explorer: add a live Follow toggle to the embedded movie86 run

### DIFF
--- a/explorer/CLAUDE.md
+++ b/explorer/CLAUDE.md
@@ -73,6 +73,9 @@ explorer/
   postcss.config.js
   index.html                    Vite entry
   explorer.mjs                  ← framework-free orchestration (tested in Node)
+  explorer.d.mts                ← sidecar TS types for explorer.mjs
+  runloop.mjs                   ← framework-free Run loop (tested in Node)
+  runloop.d.mts                 ← sidecar TS types for runloop.mjs
   src/
     main.tsx
     App.tsx                     Top-level layout / state owner
@@ -83,7 +86,7 @@ explorer/
       utils.ts                  cn(), hex helpers
       presets.ts                Bundled C snippets
     hooks/
-      useMovie86Vm.ts           Vm lifecycle + Run/Step/Reset state
+      useMovie86Vm.ts           Vm lifecycle + Run/Step/Reset/Follow state
     components/
       ui/                       shadcn primitives (Button, Card, Select, …)
       SourceEditor.tsx          CodeMirror + cpp lang
@@ -101,6 +104,7 @@ explorer/
         Console.tsx
   tests/
     unit.test.mjs               Node --test: orchestration surface
+    runloop.test.mjs            Node --test: Run-loop / live Follow toggle
     e2e/structure.spec.ts       Playwright: structural smoke
   scripts/
     stage-deploy.sh
@@ -185,6 +189,21 @@ what you compiled".
 - **Run `cargo fmt` is not us, but `npm run typecheck` is.** CI gates
   on `tsc -b --noEmit`; local dev should run `make typecheck` before
   pushing.
+- **The Follow toggle must stay *live* (re-read each loop iteration).**
+  The Movie86 panel has a "Follow" checkbox + step-delay input
+  (`vm-follow` / `vm-delay`) that switch between one-step-per-frame and
+  the batched periodic dump — same two strategies as the movie86 demo.
+  The loop lives in [`runloop.mjs`](runloop.mjs) (own copy, *not*
+  imported from `movie86/wasm/` — the subproject keeps siblings at
+  arm's length; we mirror its tested shape instead and pin it in
+  [`tests/runloop.test.mjs`](tests/runloop.test.mjs)). `useMovie86Vm`
+  mirrors `follow` / `delayMs` into refs so `readControls()` sees the
+  *current* value every iteration — that's what lets the toggle take
+  effect mid-run. If you ever capture `follow` once into the `run()`
+  closure, the toggle silently goes back to "only applies on the next
+  Run" — that was the original movie86 bug. `batchSize` / `refreshMs`
+  stay fixed per run (passed as `run()` opts); only follow/delay are
+  live.
 - **Stage-deploy order.** `.github/workflows/deploy.yaml` runs
   movfuscator-wasm → movie86/wasm → llvm-mov/wasm → explorer.
   movfuscator-wasm's step `rm -rf`s the parent `dist/` and rebuilds;

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview --host",
-    "test:unit": "node --test tests/unit.test.mjs",
+    "test:unit": "node --test",
     "test:e2e": "playwright test",
     "test": "npm run test:unit",
     "typecheck": "tsc -b --noEmit"

--- a/explorer/runloop.d.mts
+++ b/explorer/runloop.d.mts
@@ -1,0 +1,39 @@
+// Sidecar TS declarations for the framework-free run loop (runloop.mjs).
+// TS auto-picks `<basename>.d.mts` next to a .mjs import, so the React
+// hook (`src/hooks/useMovie86Vm.ts`) sees real types here while the Node
+// unit suite (`tests/runloop.test.mjs`) uses the runtime module directly.
+// Mirrors the explorer.mjs / explorer.d.mts pairing.
+
+/** Controls re-read on every loop iteration so the UI can change them
+ *  mid-run (this is what makes the Follow toggle live). */
+export interface RunLoopControls {
+    /** Follow: one step + render per frame. Off: batched periodic dump. */
+    follow: boolean;
+    /** Sleep between steps in follow mode (ms). */
+    delayMs: number;
+    /** Instructions per batch in periodic-dump mode. */
+    batchSize: bigint;
+    /** Min ms between renders in periodic-dump mode. */
+    refreshMs: number;
+}
+
+/** Side effects + inputs injected by the caller (the React hook). */
+export interface RunLoopIo {
+    /** Keep looping? false on Stop or halt. */
+    shouldContinue(): boolean;
+    /** Read the live controls for this iteration. */
+    readControls(): RunLoopControls;
+    /** Advance the Vm by one instruction. */
+    stepOne(): void;
+    /** Advance the Vm by `batchSize` instructions. */
+    stepBatch(batchSize: bigint): void;
+    /** Snapshot Vm state into React. */
+    render(): void;
+    /** Yield to the event loop so Stop stays responsive. */
+    sleep(ms: number): Promise<void>;
+    /** Monotonic clock (performance.now). */
+    now(): number;
+}
+
+/** Drive the Vm step loop until `shouldContinue()` is false. */
+export function runLoop(io: RunLoopIo): Promise<void>;

--- a/explorer/runloop.mjs
+++ b/explorer/runloop.mjs
@@ -1,0 +1,54 @@
+// Interactive Run loop for the explorer's embedded movie86 Vm.
+//
+// Like the movie86 demo, the explorer offers two display strategies
+// behind a "Follow" toggle:
+//   - Follow:        stepN(1) + render() per frame — watch each mov land.
+//   - Periodic dump: stepN(batchSize) per frame, render() only every
+//                    refreshMs — keep the wasm boundary cheap on a hot
+//                    guest. (default)
+// The two strategies live in ONE loop and the controls (follow / delay /
+// batch / refresh) are re-read via readControls() on EVERY iteration, so
+// flipping Follow — or retuning the cadence — takes effect on the next
+// step, even while a run is in flight. Reading the toggle once up front
+// (the shape movie86 originally shipped) is exactly what made it
+// impossible to switch mid-run.
+//
+// This is the explorer's OWN copy of the loop. The subproject keeps its
+// siblings at arm's length (loaded at runtime via /<subproject>/ URLs,
+// never bundled), so rather than statically import movie86/wasm's
+// runloop.mjs we own a small, framework-free copy here — same shape,
+// pinned independently by tests/runloop.test.mjs. It's pure logic: the
+// React hook (useMovie86Vm) injects stepping/rendering/timing, and
+// `runloop.d.mts` gives TS consumers the types.
+//
+// io contract:
+//   shouldContinue() -> bool   keep looping? (false on Stop / halt)
+//   readControls()    -> { follow, delayMs, batchSize, refreshMs }
+//                              read FRESH each iteration
+//   stepOne()                  advance the Vm by one instruction
+//   stepBatch(batchSize)       advance the Vm by `batchSize` instructions
+//   render()                   snapshot Vm state into React (setTick)
+//   sleep(ms)  -> Promise      yield so Stop stays responsive
+//   now()      -> ms           monotonic clock (performance.now)
+export async function runLoop(io) {
+    const { shouldContinue, readControls, stepOne, stepBatch, render, sleep, now } = io;
+    let lastRender = now();
+    while (shouldContinue()) {
+        const { follow, delayMs, batchSize, refreshMs } = readControls();
+        if (follow) {
+            stepOne();
+            render();
+            lastRender = now();
+            await sleep(delayMs);
+        } else {
+            stepBatch(batchSize);
+            const t = now();
+            if (t - lastRender >= refreshMs) {
+                render();
+                lastRender = t;
+            }
+            await sleep(0);
+        }
+    }
+    render();
+}

--- a/explorer/src/components/movie86/Movie86Panel.tsx
+++ b/explorer/src/components/movie86/Movie86Panel.tsx
@@ -53,8 +53,21 @@ interface Movie86PanelProps {
  * the explorer's intent away from "run what you compiled".
  */
 export function Movie86Panel({ elf, movie86Vm, actions }: Movie86PanelProps) {
-    const { vm, tick, running, run, step, stop, reset, loadElf, drainOutput } =
-        movie86Vm;
+    const {
+        vm,
+        tick,
+        running,
+        run,
+        step,
+        stop,
+        reset,
+        loadElf,
+        drainOutput,
+        follow,
+        setFollow,
+        delayMs,
+        setDelayMs,
+    } = movie86Vm;
 
     const [stdout, setStdout] = useState('');
     const [stderr, setStderr] = useState('');
@@ -144,6 +157,36 @@ export function Movie86Panel({ elf, movie86Vm, actions }: Movie86PanelProps) {
                             <RefreshCw className="h-3.5 w-3.5" />
                             Reset
                         </Button>
+                        <label
+                            className="flex items-center gap-1.5 text-xs text-muted-foreground select-none"
+                            title="Follow: step one instruction per frame and redraw every step (watch each mov land). Off: run in fast batches and refresh periodically. Toggle any time — including mid-run."
+                        >
+                            <input
+                                type="checkbox"
+                                className="h-3.5 w-3.5 accent-primary"
+                                checked={follow}
+                                onChange={(e) => setFollow(e.target.checked)}
+                                data-testid="vm-follow"
+                            />
+                            Follow
+                        </label>
+                        <label
+                            className="flex items-center gap-1 text-xs text-muted-foreground"
+                            title="Step delay (ms) between instructions while Follow is on."
+                        >
+                            delay
+                            <input
+                                type="number"
+                                min={0}
+                                step={50}
+                                value={delayMs}
+                                onChange={(e) => setDelayMs(Number(e.target.value))}
+                                disabled={!follow}
+                                className="w-14 rounded-md border bg-background px-1.5 py-0.5 text-xs tabular-nums disabled:opacity-50"
+                                data-testid="vm-delay"
+                            />
+                            ms
+                        </label>
                         <Button
                             variant="outline"
                             size="sm"

--- a/explorer/src/hooks/useMovie86Vm.ts
+++ b/explorer/src/hooks/useMovie86Vm.ts
@@ -1,5 +1,9 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { loadMovie86, type Movie86Vm, type Movie86Wrapper } from '@/lib/wrappers';
+// Framework-free run loop (pure ESM + sidecar .d.mts), node-tested in
+// tests/runloop.test.mjs. Owned here rather than imported from the
+// movie86 subproject — same arm's-length pattern as explorer.mjs.
+import { runLoop } from '../../runloop.mjs';
 
 export interface VmTick {
     eip: number;
@@ -27,6 +31,15 @@ export interface UseMovie86VmReturn {
     stop: () => void;
     reset: () => Promise<void>;
     running: boolean;
+    /** Follow mode: one step + render per frame (watch each mov) vs the
+     *  default batched periodic dump. Read live by the run loop, so
+     *  toggling it mid-run takes effect on the next step. */
+    follow: boolean;
+    setFollow: (v: boolean) => void;
+    /** Step delay (ms) between instructions while Follow is on. Also
+     *  read live mid-run. */
+    delayMs: number;
+    setDelayMs: (v: number) => void;
     refresh: () => void;
     /** Pulls accumulated stdout/stderr bytes off the Vm. Called on
      *  every render tick. Buffers persist across drains. */
@@ -50,6 +63,25 @@ export function useMovie86Vm(): UseMovie86VmReturn {
 
     const elfBytesRef = useRef<Uint8Array | null>(null);
     const runIdRef = useRef(0);
+
+    // Follow / step-delay are mirrored into refs so the run loop reads
+    // their *current* value each iteration (state captured in the run()
+    // closure would be stale). The setters update both so the UI stays
+    // controlled and the live loop sees the change immediately.
+    const [follow, setFollowState] = useState(false);
+    const followRef = useRef(false);
+    const setFollow = useCallback((v: boolean) => {
+        followRef.current = v;
+        setFollowState(v);
+    }, []);
+
+    const [delayMs, setDelayState] = useState(0);
+    const delayRef = useRef(0);
+    const setDelayMs = useCallback((v: number) => {
+        const clamped = Math.max(0, Math.floor(v) || 0);
+        delayRef.current = clamped;
+        setDelayState(clamped);
+    }, []);
 
     useEffect(() => {
         let cancelled = false;
@@ -108,18 +140,25 @@ export function useMovie86Vm(): UseMovie86VmReturn {
             if (!vm || vm.haltReason) return;
             const myRun = ++runIdRef.current;
             setRunning(true);
-            let lastRender = performance.now();
+            // follow / delay are read live from refs each iteration so
+            // the toggle works mid-run; batch / refresh are fixed for
+            // this run (the caller's cadence for the periodic-dump mode).
             try {
-                while (myRun === runIdRef.current && !vm.haltReason) {
-                    vm.stepN(batchSize);
-                    const now = performance.now();
-                    if (now - lastRender >= refreshMs) {
-                        setTick(sampleTick(vm));
-                        lastRender = now;
-                    }
-                    await new Promise((r) => setTimeout(r, 0));
-                }
-                setTick(sampleTick(vm));
+                await runLoop({
+                    shouldContinue: () =>
+                        myRun === runIdRef.current && !vm.haltReason,
+                    readControls: () => ({
+                        follow: followRef.current,
+                        delayMs: delayRef.current,
+                        batchSize,
+                        refreshMs,
+                    }),
+                    stepOne: () => vm.stepN(1n),
+                    stepBatch: (n) => vm.stepN(n),
+                    render: () => setTick(sampleTick(vm)),
+                    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+                    now: () => performance.now(),
+                });
             } finally {
                 if (myRun === runIdRef.current) setRunning(false);
             }
@@ -152,6 +191,10 @@ export function useMovie86Vm(): UseMovie86VmReturn {
         stop,
         reset,
         running,
+        follow,
+        setFollow,
+        delayMs,
+        setDelayMs,
         refresh,
         drainOutput,
     };

--- a/explorer/src/hooks/useMovie86Vm.ts
+++ b/explorer/src/hooks/useMovie86Vm.ts
@@ -31,9 +31,9 @@ export interface UseMovie86VmReturn {
     stop: () => void;
     reset: () => Promise<void>;
     running: boolean;
-    /** Follow mode: one step + render per frame (watch each mov) vs the
-     *  default batched periodic dump. Read live by the run loop, so
-     *  toggling it mid-run takes effect on the next step. */
+    /** Follow mode (default on): one step + render per frame (watch
+     *  each mov) vs the batched periodic dump. Read live by the run
+     *  loop, so toggling it mid-run takes effect on the next step. */
     follow: boolean;
     setFollow: (v: boolean) => void;
     /** Step delay (ms) between instructions while Follow is on. Also
@@ -68,8 +68,11 @@ export function useMovie86Vm(): UseMovie86VmReturn {
     // their *current* value each iteration (state captured in the run()
     // closure would be stale). The setters update both so the UI stays
     // controlled and the live loop sees the change immediately.
-    const [follow, setFollowState] = useState(false);
-    const followRef = useRef(false);
+    // Default to Follow on — the explorer runs small, freshly-compiled
+    // programs you want to watch instruction-by-instruction; the user
+    // can flip to fast batch mode any time, including mid-run.
+    const [follow, setFollowState] = useState(true);
+    const followRef = useRef(true);
     const setFollow = useCallback((v: boolean) => {
         followRef.current = v;
         setFollowState(v);

--- a/explorer/tests/e2e/structure.spec.ts
+++ b/explorer/tests/e2e/structure.spec.ts
@@ -35,6 +35,32 @@ test('Explorer renders the major panes', async ({ page }) => {
     await expect(page.getByTestId('turbo86-handover')).toBeVisible();
 });
 
+test('Movie86 panel exposes a live Follow toggle + step-delay control', async ({
+    page,
+}) => {
+    await page.goto('/');
+
+    const follow = page.getByTestId('vm-follow');
+    const delay = page.getByTestId('vm-delay');
+    await expect(follow).toBeVisible();
+    await expect(delay).toBeVisible();
+
+    // Default is batch (Follow off); the delay input is only meaningful
+    // in follow mode, so it starts disabled.
+    await expect(follow).not.toBeChecked();
+    await expect(delay).toBeDisabled();
+
+    // Flipping Follow enables the delay control — the toggle is plain
+    // UI state, so this works without a loaded Vm (and, in turn, can be
+    // flipped while a run is in flight). The run loop reads it live.
+    await follow.check();
+    await expect(follow).toBeChecked();
+    await expect(delay).toBeEnabled();
+
+    await follow.uncheck();
+    await expect(delay).toBeDisabled();
+});
+
 test('Compiler select hides the IR column when movfuscator is chosen', async ({ page }) => {
     await page.goto('/');
     // The IR column is mounted initially (llvm-mov default).

--- a/explorer/tests/e2e/structure.spec.ts
+++ b/explorer/tests/e2e/structure.spec.ts
@@ -45,20 +45,20 @@ test('Movie86 panel exposes a live Follow toggle + step-delay control', async ({
     await expect(follow).toBeVisible();
     await expect(delay).toBeVisible();
 
-    // Default is batch (Follow off); the delay input is only meaningful
-    // in follow mode, so it starts disabled.
-    await expect(follow).not.toBeChecked();
-    await expect(delay).toBeDisabled();
-
-    // Flipping Follow enables the delay control — the toggle is plain
-    // UI state, so this works without a loaded Vm (and, in turn, can be
-    // flipped while a run is in flight). The run loop reads it live.
-    await follow.check();
+    // Default is Follow on (watch each mov land), so the step-delay
+    // input — only meaningful in follow mode — starts enabled.
     await expect(follow).toBeChecked();
     await expect(delay).toBeEnabled();
 
+    // Toggling is plain UI state, so it works without a loaded Vm (and,
+    // in turn, can be flipped while a run is in flight — the run loop
+    // reads it live). Off disables the delay input; on re-enables it.
     await follow.uncheck();
+    await expect(follow).not.toBeChecked();
     await expect(delay).toBeDisabled();
+
+    await follow.check();
+    await expect(delay).toBeEnabled();
 });
 
 test('Compiler select hides the IR column when movfuscator is chosen', async ({ page }) => {

--- a/explorer/tests/runloop.test.mjs
+++ b/explorer/tests/runloop.test.mjs
@@ -1,0 +1,91 @@
+// Node-level unit tests for the explorer's interactive Run loop
+// (`../runloop.mjs`). Run via `node --test` (wired into `make test-unit`).
+//
+// The explorer embeds the movie86 Vm and — like the movie86 demo — wants
+// two display strategies behind a "Follow" toggle: one-step-per-frame
+// (watch each mov land) vs refreshMs-throttled batch (keep up on a hot
+// guest). The headline requirement, and the bug movie86 just fixed, is
+// that the loop must read the controls FRESH every iteration so the
+// Follow toggle (and step delay) can be flipped *mid-run*. These tests
+// pin that without React or wasm by injecting every side effect.
+//
+// This is the explorer's own copy of the loop (it deliberately keeps the
+// sibling subprojects at arm's length — runtime URL, no bundling — so it
+// doesn't import movie86/wasm/runloop.mjs). The shape is intentionally
+// the same; this suite is what keeps the two honest independently.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { runLoop } from '../runloop.mjs';
+
+// Live Follow toggle: start in follow mode, flip it off after the second
+// step. The loop must switch to batch stepping immediately — only
+// possible if it re-reads readControls() each iteration.
+test('reads Follow fresh each iteration (live toggle)', async () => {
+    let i = 0;
+    let follow = true;
+    const seq = [];
+    await runLoop({
+        shouldContinue: () => i < 4,
+        readControls: () => ({ follow, delayMs: 0, batchSize: 100n, refreshMs: 0 }),
+        stepOne: () => { seq.push('one'); i++; if (i === 2) follow = false; },
+        stepBatch: () => { seq.push('batch'); i++; },
+        render: () => {},
+        sleep: async () => {},
+        now: () => 0,
+    });
+    assert.deepEqual(seq, ['one', 'one', 'batch', 'batch']);
+});
+
+test('follow mode steps once and renders every iteration', async () => {
+    let i = 0, ones = 0, renders = 0;
+    await runLoop({
+        shouldContinue: () => i < 3,
+        readControls: () => ({ follow: true, delayMs: 0, batchSize: 1n, refreshMs: 0 }),
+        stepOne: () => { ones++; i++; },
+        stepBatch: () => { throw new Error('stepBatch must not run in follow mode'); },
+        render: () => { renders++; },
+        sleep: async () => {},
+        now: () => 0,
+    });
+    assert.equal(ones, 3);
+    assert.equal(renders, 3 + 1, 'per-iteration renders plus one final render');
+});
+
+// Scripted clock so the refreshMs throttle is deterministic:
+//   call 1 (pre-loop lastRender) -> 0
+//   iter 1 -> 50  (<100: no render)   iter 2 -> 150 (>=100: render)
+//   iter 3 -> 200 (<100: no render)   iter 4 -> 320 (>=100: render)
+// Two in-loop renders + one unconditional final render = 3.
+test('batch mode throttles render by refreshMs and renders once at the end', async () => {
+    let i = 0, renders = 0;
+    const sizes = [];
+    const clock = [0, 50, 150, 200, 320];
+    let tick = 0;
+    await runLoop({
+        shouldContinue: () => i < 4,
+        readControls: () => ({ follow: false, delayMs: 0, batchSize: 10n, refreshMs: 100 }),
+        stepOne: () => { throw new Error('stepOne must not run in batch mode'); },
+        stepBatch: (n) => { sizes.push(n); i++; },
+        render: () => { renders++; },
+        sleep: async () => {},
+        now: () => clock[tick++],
+    });
+    assert.equal(renders, 3, 'two throttled renders + one final render');
+    assert.deepEqual(sizes, [10n, 10n, 10n, 10n], 'batchSize forwarded to stepBatch');
+});
+
+test('does not step when shouldContinue is false from the start', async () => {
+    let steps = 0, renders = 0;
+    await runLoop({
+        shouldContinue: () => false,
+        readControls: () => ({ follow: true, delayMs: 0, batchSize: 1n, refreshMs: 0 }),
+        stepOne: () => { steps++; },
+        stepBatch: () => { steps++; },
+        render: () => { renders++; },
+        sleep: async () => {},
+        now: () => 0,
+    });
+    assert.equal(steps, 0, 'no stepping when the loop should not run');
+    assert.equal(renders, 1, 'still flushes one final render');
+});


### PR DESCRIPTION
## What

explorer の埋め込み movie86 に **Follow トグル + step-delay** を追加。movie86 デモと同様に「1命令ずつ追って見る」モードと「高速バッチ + 定期更新」モードを切り替えられる。さらに **run 中にライブで切り替え可能**。

## Why

これまで explorer の埋め込み movie86 は batch モードの Run のみで、命令単位で実行を眺める手段が無かった（movie86 デモの「Follow execution」相当が欠けていた）。

## How

- `useMovie86Vm` が `follow` / `delayMs` を **ref にミラー**し、run ループが**毎イテレーション** `readControls()` で現在値を読む。これにより run 中のトグル変更が次ステップで反映される（movie86 で直したのと同じ「都度読み」原則。`run()` クロージャに一度束縛すると "次の Run まで効かない" バグになる）。
- ループは framework-free な `runloop.mjs`（+ サイドカー `runloop.d.mts`）に切り出し、`explorer.mjs` と同じパターンで Node 単体テスト可能に。
- **explorer 専用の自前コピー**であり `movie86/wasm/runloop.mjs` の import ではない。explorer はサブプロジェクトを実行時 `/<subproject>/` URL で疎結合に保つ方針（bundle しない）なので、movie86 の検証済み形状をミラーし、`tests/runloop.test.mjs` で独立に担保する。

## Tests / Verification

- **単体（node --test）** `tests/runloop.test.mjs`: ライブトグル / follow 毎フレーム描画 / refreshMs スロットル / shouldContinue ゲート。TDD で先に red → 実装 → green。`test:unit` は `node --test` 自動ディスカバリに変更（今後の `*.test.mjs` も自動収集）。
- **構造 e2e（Playwright）**: `vm-follow` / `vm-delay` の表示と、Follow が delay 入力を gate することをアサート（5/5 パス）。
- **typecheck / build**: `tsc -b` + `vite build` 通過（`.mjs` は `runloop.d.mts` で型解決、アプリチャンクにバンドル）。
- **実ブラウザ E2E**: ヘッドレス chromium を CDP 駆動。preview に cycle.elf をアップロード → Run → run 中に Follow を ON→OFF→ON。`total mov` の増加レートが約19000倍スイングして戻ることを確認（ref→readControls のライブ配線を実証）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)