### PR TITLE
explorer: example preset を追加 (fizzbuzz / fib / mode-13h mandelbrot)

### DIFF
--- a/explorer/CLAUDE.md
+++ b/explorer/CLAUDE.md
@@ -135,9 +135,14 @@ turbo86. Everything else is supporting cast.
 There is exactly one optional escape hatch: the **Upload** button in
 the Movie86 panel header (`data-testid="elf-upload"`), for the case
 where the user wants to drop in an arbitrary static ELF instead of
-the just-compiled one. **Do not** reintroduce pre-built "example"
-preset dropdowns — that would push the page's intent away from "run
-what you compiled".
+the just-compiled one. **Do not** reintroduce a pre-built *fixture*
+dropdown that loads compiled ELFs and skips the toolchain — that's the
+thing PR-era commit `5580b7e` removed, and it pushes the page away from
+"run what you compiled". The **source** preset menu (`presets.ts`) is
+the opposite and stays: it drops editable C into the editor that the
+user then compiles + runs themselves. Adding source presets — even a
+heavyweight one like the mode-13h `mandelbrot` that renders in the
+Canvas pane — is in-intent.
 
 ## Known limitations
 
@@ -167,6 +172,24 @@ what you compiled".
 
 ## Things future Claude shouldn't relearn
 
+- **Canvas presets ride a *link profile*, not a special pipeline.** A
+  preset that needs more than the bare `_start.o + <user>.o` static
+  link names a `linkProfile` (today only `'canvas13h'`); `explorer.mjs`
+  expands it (`LINK_PROFILES`) into an extra assembled stubs object +
+  raw `ld` flags. `canvas13h` links the mov-only ABI stubs
+  (`set_video_mode` / `mmap_request` / `exit`) and pins a `.fb13h` BSS
+  section at the VGA base `0xA0000` via
+  `--section-start=.fb13h=0xA0000 --undefined=_fb13h_region`. Those raw
+  flags reach `ld` through `movfuscator-wasm` `link()`'s `extraLdArgs`
+  (added alongside this profile; defaults to `[]` so every byte-
+  identical golden is unchanged). The embedded movie86 needs **no**
+  changes — `Canvas.tsx` already reads `vm.activeVideoMode` + the
+  framebuffer, and the loader pre-maps the `PT_LOAD` at `0xA0000`.
+  Canvas presets only *run* on the **llvm-mov** path (the movfuscator
+  path's externs stay undefined dynamic symbols — inspectable, not
+  runnable, like every movfuscator-path ELF today). The mov-only ABI
+  asm lives in `explorer.mjs`, never in the preset data, so presets
+  stay pure source strings.
 - **Don't bundle the sibling wrappers** (see Operating model #2). If
   TypeScript starts complaining that the runtime import URL can't be
   resolved, the fix is to keep the dynamic `import()` and refine the

--- a/explorer/explorer.mjs
+++ b/explorer/explorer.mjs
@@ -70,6 +70,72 @@ _start:
     mov [0x1FFE00FE], eax
 `;
 
+// mov-only ABI stubs + framebuffer BSS for the `canvas13h` link
+// profile. Mirrors `movie86/wasm/examples/sources/stubs_llvm.s`. A
+// canvas program (mode-13h mandelbrot) reaches three host services
+// purely by writing into the unmapped ABI page at 0x1FFE_0000 —
+// movie86's AbiHost decodes the page offset as the call number and the
+// stored value as the argument:
+//
+//   set_video_mode(mode) → [0x1FFE0010] = mode   (CALL_SET_VIDEO_MODE)
+//   mmap_request(packed)  → [0x1FFE0020] = packed (CALL_MMAP_REQUEST)
+//   exit(code)            → [0x1FFE00FE] = code   (CALL_EXIT)
+//
+// `ret` becomes `pop ecx ; jmp ecx` so the linked .text carries no
+// `ret` opcode (upstream "100% mov+jmp" goal); `exit` needs no tail at
+// all — the ABI store unmaps the process before the next fetch, which
+// is also why a `main` that tail-calls `exit` never returns to the
+// `_start` above.
+//
+// The `.fb13h` nobits section is 320*200*4 B at guest 0xA0000. The
+// matching `--section-start=.fb13h=0xA0000` ld flag (from the
+// canvas13h profile) makes the linker emit a PT_LOAD there, which
+// movie86's loader pre-maps — so the guest's pixel stores land in the
+// framebuffer the embedded Canvas pane reads via `vm.readMem(0xA0000,
+// …)`. `_fb13h_region` is held live with `--undefined=` so a GC pass
+// can't drop the otherwise-unreferenced section.
+export const STUBS_CANVAS13H_S = `\
+.intel_syntax noprefix
+.section .text
+
+.globl set_video_mode
+set_video_mode:
+    mov eax, [esp + 4]
+    mov [0x1FFE0010], al
+    pop ecx
+    jmp ecx
+
+.globl mmap_request
+mmap_request:
+    mov eax, [esp + 4]
+    mov [0x1FFE0020], eax
+    pop ecx
+    jmp ecx
+
+.globl exit
+exit:
+    mov eax, [esp + 4]
+    mov [0x1FFE00FE], eax
+
+.section .fb13h, "aw", @nobits
+.globl _fb13h_region
+_fb13h_region:
+.skip 256000
+`;
+
+// Declarative link profiles. A preset that needs more than the bare
+// `_start.o + <user>.o` static link names a profile; the llvm-mov
+// branch expands it into (extra assembled object, raw ld flags).
+// Keeping the recipe here — not in the preset data — lets presets stay
+// pure C source strings and keeps the mov-only ABI asm in one place.
+export const LINK_PROFILES = Object.freeze({
+    canvas13h: {
+        stubsName: 'stubs.o',
+        stubsAsm: STUBS_CANVAS13H_S,
+        extraLdArgs: ['--section-start=.fb13h=0xA0000', '--undefined=_fb13h_region'],
+    },
+});
+
 /**
  * Compile C source through the selected mov-only toolchain.
  *
@@ -85,7 +151,16 @@ _start:
  *   mounted in MEMFS root so source can `#include "name.h"`
  *   (movfuscator only — clang already embeds the resource-dir headers)
  * @param {object} [params.opts.linkOpts] — forwarded to
- *   `movfuscator.link()` (extraLibs / searchPaths / extraInputs)
+ *   `movfuscator.link()` (extraLibs / searchPaths / extraInputs /
+ *   extraLdArgs)
+ * @param {'canvas13h'} [params.opts.linkProfile] — named link recipe
+ *   for presets that need more than the bare static link (llvm-mov path
+ *   only). `'canvas13h'` links the mov-only ABI framebuffer stubs and
+ *   pins a `.fb13h` BSS section at the VGA base 0xA0000 so a mode-13h
+ *   program renders in the embedded Canvas pane. Ignored on the
+ *   movfuscator path (its externs stay undefined dynamic symbols — the
+ *   output is inspectable but, like every movfuscator-path ELF today,
+ *   not movie86-runnable).
  * @param {(stage: string) => void} [params.opts.onProgress]
  * @param {object} [params.wrappers] — dependency injection for tests
  * @returns {Promise<{
@@ -161,10 +236,25 @@ export async function compileWithCompiler(params) {
             '_start.o': startObj,
             'explorer.o': obj,
         };
+        // Expand a named link profile (e.g. canvas13h) into its extra
+        // assembled object + raw ld flags. The profile's flags merge
+        // *before* the caller's linkOpts so an explicit caller override
+        // still wins the spread below.
+        const profileLinkOpts = {};
+        const profile = opts.linkProfile ? LINK_PROFILES[opts.linkProfile] : undefined;
+        if (opts.linkProfile && !profile) {
+            throw new Error(`unknown linkProfile: ${opts.linkProfile} (want one of: ${Object.keys(LINK_PROFILES).join(', ')})`);
+        }
+        if (profile) {
+            onProgress('assemble-stubs');
+            linkInputs[profile.stubsName] = await w.movfuscator.assemble(profile.stubsAsm);
+            profileLinkOpts.extraLdArgs = profile.extraLdArgs;
+        }
         const userLinkOpts = opts.linkOpts ?? {};
         elf = await w.movfuscator.link(linkInputs, undefined, {
             static: true,
             runtime: 'none',
+            ...profileLinkOpts,
             ...userLinkOpts,
         });
     } else {

--- a/explorer/src/App.tsx
+++ b/explorer/src/App.tsx
@@ -88,12 +88,18 @@ export function App() {
                 .split(/\s+/)
                 .map((s) => s.trim())
                 .filter(Boolean);
+            // The selected preset can carry a link profile (e.g. the
+            // mandelbrot's canvas13h, which wires the framebuffer stubs
+            // + pins .fb13h at 0xA0000). It follows the preset, not the
+            // (possibly hand-edited) source text.
+            const linkProfile = PRESETS.find((p) => p.id === presetId)?.linkProfile;
             const res = await compile({
                 compiler,
                 source,
                 opts: {
                     optLevel,
                     clangFlags: flags,
+                    linkProfile,
                     onProgress: (stage) =>
                         setStatusBar({ kind: 'busy', text: `compiling — ${stage}` }),
                 },
@@ -111,7 +117,7 @@ export function App() {
         } finally {
             setBusy(false);
         }
-    }, [compiler, source, optLevel, extraFlags]);
+    }, [compiler, source, optLevel, extraFlags, presetId]);
 
     const elf = useMemo(() => result?.elf ?? null, [result]);
 

--- a/explorer/src/lib/compiler.ts
+++ b/explorer/src/lib/compiler.ts
@@ -32,7 +32,17 @@ export interface CompileParams {
             extraLibs?: string[];
             searchPaths?: string[];
             extraInputs?: Record<string, Uint8Array>;
+            /** Raw `ld` flags spliced in verbatim (one slot per entry).
+             *  The canvas13h link profile uses this for
+             *  `--section-start` / `--undefined`; callers rarely set it
+             *  directly. */
+            extraLdArgs?: string[];
         };
+        /** Named link recipe (llvm-mov path only). `'canvas13h'` links
+         *  the mov-only ABI framebuffer stubs + pins `.fb13h` at the VGA
+         *  base so a mode-13h program renders in the Canvas pane. Driven
+         *  by the selected preset's `linkProfile`. */
+        linkProfile?: 'canvas13h';
         onProgress?: (stage: string) => void;
     };
 }

--- a/explorer/src/lib/presets.ts
+++ b/explorer/src/lib/presets.ts
@@ -1,11 +1,21 @@
 // Bundled C snippets — quick-start examples wired into the source
-// editor's preset menu. Kept short on purpose; deeper examples (md5,
-// mandelbrot) live in the per-compiler subprojects already.
+// editor's preset menu. They load editable source you then Compile and
+// Run (the "run what you compiled" intent) — distinct from the removed
+// pre-built *fixture* dropdown. Most stay short; `mandelbrot` is the
+// deliberate heavyweight that shows real computation driving the
+// embedded Canvas pane through the mov-only ABI.
 
 export interface Preset {
     id: string;
     label: string;
     source: string;
+    /** Named link recipe for presets that need more than the bare
+     *  `_start.o + <user>.o` static link (llvm-mov path only). See
+     *  `explorer.mjs`'s `LINK_PROFILES`. `'canvas13h'` links the
+     *  mov-only ABI framebuffer stubs and pins a `.fb13h` BSS section
+     *  at the VGA base 0xA0000 so a mode-13h program renders in the
+     *  Canvas pane. Omit for plain compute / printf examples. */
+    linkProfile?: 'canvas13h';
 }
 
 export const PRESETS: readonly Preset[] = [
@@ -56,6 +66,123 @@ int main(void) {
         if (is_prime(i)) printf("%d ", i);
     printf("\\n");
     return 0;
+}
+`,
+    },
+    {
+        id: 'fizzbuzz',
+        label: 'fizzbuzz — classic 1..30',
+        source: `#include <stdio.h>
+
+int main(void) {
+    int i;
+    for (i = 1; i <= 30; i++) {
+        if (i % 15 == 0)      printf("FizzBuzz\\n");
+        else if (i % 3 == 0)  printf("Fizz\\n");
+        else if (i % 5 == 0)  printf("Buzz\\n");
+        else                  printf("%d\\n", i);
+    }
+    return 0;
+}
+`,
+    },
+    {
+        id: 'fib',
+        label: 'fib — n-th Fibonacci (recursive)',
+        // Recursive on purpose: each `call fib` becomes llvm-mov
+        // stage-7d3's CALL32d → JMP32d_CALL mov-only rewrite, so the
+        // IR / asm panes show how a mov-only target fakes a call stack
+        // with no real `call`/`ret`. (An iterative two-accumulator loop
+        // is faster and avoids the ~177 recursive calls of fib(10), but
+        // hides that — swap it in if you'd rather show the loop form.)
+        source: `int fib(int n) {
+    if (n < 2) return n;
+    return fib(n - 1) + fib(n - 2);
+}
+
+int main(void) {
+    return fib(10);  /* expect exit code 55 */
+}
+`,
+    },
+    {
+        id: 'mandelbrot',
+        label: 'mandelbrot — mode-13h fractal (Canvas)',
+        // Runs end-to-end on the llvm-mov path only: it sets VGA mode 13h
+        // and writes RGBA pixels into the framebuffer the canvas13h link
+        // profile pins at guest 0xA0000, which the embedded Canvas pane
+        // renders. Fixed-point Q16.16 escape-time iteration. Heavy: every
+        // C statement becomes hundreds of mov-only instructions and each
+        // of those hundreds of master-loop iterations, so it computes a
+        // coarse 80×50 grid blitted as 4×4 blocks — still many millions
+        // of guest instructions and minutes of wall time. That cost *is*
+        // the demo: real computation through a mov-only emulator.
+        linkProfile: 'canvas13h',
+        source: `/* Mode-13h Mandelbrot — fixed-point Q16.16, escape-time iteration.
+ * The .fb13h framebuffer at 0xA0000 + the set_video_mode / mmap_request
+ * / exit stubs are supplied by the explorer's canvas13h link profile. */
+#define FB_ADDR  0xA0000   /* mode 13h base */
+#define FB_W     320
+#define CW       80        /* compute grid width  (CW * 4 == FB_W) */
+#define CH       50        /* compute grid height (CH * 4 == 200)  */
+#define MAX_ITER 8
+
+typedef int fp_t;          /* Q16.16 */
+
+extern void set_video_mode(unsigned mode);
+extern void mmap_request(unsigned packed);
+extern void exit(int code) __attribute__((noreturn));
+
+/* Pack (addr, pages) for the mov-only ABI mmap_request call. */
+#define ABI_MMAP_PACK(addr, pages) ((unsigned)(addr) | (unsigned)((pages) - 1))
+#define FB13H_MMAP ABI_MMAP_PACK(0x000A0000U, 64)
+
+static fp_t fmul(fp_t a, fp_t b) {
+    long long p = (long long)a * (long long)b;
+    return (fp_t)(p >> 16);
+}
+
+int main(void) {
+    unsigned *fb;
+    int py, px, i, dy, dx;
+    fp_t cx, cy, x, y, xx, yy, xy;
+    unsigned color, t;
+
+    mmap_request(FB13H_MMAP);
+    set_video_mode(0x13);
+    fb = (unsigned *)FB_ADDR;
+
+    /* Window re∈[-2.5,1.5], im∈[-1.25,1.25]; Q16.16 step 3276/cell. */
+    for (py = 0; py < CH; py++) {
+        cy = -81920 + py * 3276;
+        for (px = 0; px < CW; px++) {
+            cx = -163840 + px * 3276;
+            x = 0; y = 0;
+            for (i = 0; i < MAX_ITER; i++) {
+                xx = fmul(x, x);
+                yy = fmul(y, y);
+                if (xx + yy > (4 << 16)) break;
+                xy = fmul(x, y);
+                x = xx - yy + cx;
+                y = xy + xy + cy;
+            }
+            if (i >= MAX_ITER) {
+                color = 0xFF000000u;   /* interior — opaque black */
+            } else {
+                t = (unsigned)i * (256u / MAX_ITER);
+                if (t > 255u) t = 255u;
+                /* teal → yellow ramp, RGBA u32 LE */
+                color = (0xFFu << 24) | ((255u - t) << 16) | (t << 8) | t;
+            }
+            /* Blit a 4×4 block per compute pixel. */
+            for (dy = 0; dy < 4; dy++)
+                for (dx = 0; dx < 4; dx++)
+                    fb[(py * 4 + dy) * FB_W + (px * 4 + dx)] = color;
+        }
+    }
+
+    exit(0);
+    return 0;  /* unreachable */
 }
 `,
     },

--- a/explorer/src/lib/wrappers.ts
+++ b/explorer/src/lib/wrappers.ts
@@ -33,6 +33,10 @@ export interface MovfuscatorWrapper {
             extraLibs?: string[];
             searchPaths?: string[];
             extraInputs?: Record<string, Uint8Array>;
+            /** Raw `ld` flags spliced in after the mode switch, before
+             *  `-L`/objects. Used by the canvas13h profile for
+             *  `--section-start` / `--undefined`. */
+            extraLdArgs?: string[];
         },
     ): Promise<Uint8Array>;
     compileToElf(

--- a/explorer/tests/unit.test.mjs
+++ b/explorer/tests/unit.test.mjs
@@ -186,3 +186,95 @@ test('compileWithCompiler — caller linkOpts override the llvm-mov defaults', a
     assert.equal(calls[0].opts.runtime, 'movfuscator',
         'caller can opt back to the movfuscator CRT');
 });
+
+test("compileWithCompiler — linkProfile 'canvas13h' wires the framebuffer stubs (llvm-mov)", async () => {
+    // The explorer's canvas presets (mode-13h mandelbrot) need three
+    // things the plain llvm-mov path doesn't: the mov-only ABI stubs
+    // (`set_video_mode` / `mmap_request` / `exit`) plus a `.fb13h` BSS
+    // section pinned at the VGA base 0xA0000. `opts.linkProfile:
+    // 'canvas13h'` is the declarative switch that assembles the stubs
+    // object, threads it into the link inputs, and injects the two raw
+    // ld flags (`--section-start` + `--undefined`). The mov-only-ABI asm
+    // lives in explorer.mjs, not in the preset data, so presets stay
+    // pure source strings.
+    const calls = [];
+    const wrappers = {
+        movfuscator: {
+            assemble: async (asm) => {
+                calls.push(['assemble', asm]);
+                // Tag each assembled object by which recipe it came from
+                // so the link assertions can identify them.
+                if (asm.includes('_start:')) return new Uint8Array([1]);
+                if (asm.includes('set_video_mode')) return new Uint8Array([2]);
+                return new Uint8Array([3]);
+            },
+            link: async (objs, libs, opts) => {
+                calls.push(['link', objs, opts]);
+                return new Uint8Array([0x7f, 0x45]);
+            },
+        },
+        llvmMov: {
+            cToIR: async () => 'ir',
+            compile: async () => 'asm',
+        },
+    };
+    const { compileWithCompiler } = await import('../explorer.mjs');
+    await compileWithCompiler({
+        compiler: 'llvm-mov',
+        source: 'int main(void){ return 0; }',
+        opts: { linkProfile: 'canvas13h' },
+        wrappers,
+    });
+
+    // The stubs source must be assembled (in addition to user asm +
+    // _start.s), so `assemble` runs three times for the canvas profile.
+    const assembleCalls = calls.filter((c) => c[0] === 'assemble');
+    assert.ok(
+        assembleCalls.some((c) => c[1].includes('set_video_mode')),
+        'canvas13h must assemble the mov-only ABI framebuffer stubs',
+    );
+
+    const [, linkObjs, linkOpts] = calls.find((c) => c[0] === 'link');
+    assert.ok(!(linkObjs instanceof Uint8Array), 'link inputs must be a Record');
+    assert.deepEqual(
+        Object.keys(linkObjs),
+        ['_start.o', 'explorer.o', 'stubs.o'],
+        'stubs.o must join _start.o + the user object in the link inputs',
+    );
+    assert.equal(linkOpts.static, true, 'canvas13h still links statically');
+    assert.equal(linkOpts.runtime, 'none', 'canvas13h keeps runtime: none');
+    assert.deepEqual(
+        linkOpts.extraLdArgs,
+        ['--section-start=.fb13h=0xA0000', '--undefined=_fb13h_region'],
+        'canvas13h must pin .fb13h at 0xA0000 and keep its region symbol live',
+    );
+});
+
+test('compileWithCompiler — no linkProfile leaves the llvm-mov link inputs minimal', async () => {
+    // Regression guard: the default (profile-less) llvm-mov path must
+    // NOT link the canvas stubs or inject section-start flags — every
+    // existing preset (return42, hello, …) links just `_start.o` + the
+    // user object, with no extraLdArgs.
+    const calls = [];
+    const wrappers = {
+        movfuscator: {
+            assemble: async () => new Uint8Array([1]),
+            link: async (objs, libs, opts) => {
+                calls.push({ objs, opts });
+                return new Uint8Array([0x7f]);
+            },
+        },
+        llvmMov: { cToIR: async () => 'ir', compile: async () => 'asm' },
+    };
+    const { compileWithCompiler } = await import('../explorer.mjs');
+    await compileWithCompiler({
+        compiler: 'llvm-mov',
+        source: 'int main(void){ return 0; }',
+        wrappers,
+    });
+    const { objs, opts } = calls[0];
+    assert.deepEqual(Object.keys(objs), ['_start.o', 'explorer.o'],
+        'default path links no stubs.o');
+    assert.equal(opts.extraLdArgs, undefined,
+        'default path injects no raw ld flags');
+});

--- a/movfuscator-wasm/movfuscator.d.ts
+++ b/movfuscator-wasm/movfuscator.d.ts
@@ -53,6 +53,13 @@ export interface LinkOptions {
    *  `searchPaths` then resolve. Paths must be absolute and outside the
    *  directories the wrapper relies on (e.g., `/movfuscator/`). */
   extraInputs?: Record<string, Uint8Array>;
+  /** Raw `ld` flags spliced in right after the mode switch (before
+   *  `-L`/objects), for position-independent options with no dedicated
+   *  knob — e.g. `'--section-start=.fb13h=0xA0000'` and
+   *  `'--undefined=_fb13h_region'` to pin + retain a canvas framebuffer
+   *  BSS section. One argv slot per array element. Defaults to `[]`,
+   *  leaving every existing link command byte-identical. */
+  extraLdArgs?: string[];
 }
 
 /** Run the LCC C preprocessor on `source`. Returns the post-`#include`

--- a/movfuscator-wasm/movfuscator.mjs
+++ b/movfuscator-wasm/movfuscator.mjs
@@ -279,6 +279,7 @@ function assertSafeExtraInputPath(p, userObjPaths) {
  *   extraLibs?: string[],
  *   searchPaths?: string[],
  *   extraInputs?: Record<string,Uint8Array>,
+ *   extraLdArgs?: string[],
  * }} [opts]
  *   - `name`: only used when `objs` is a single Uint8Array. Default `a.out.o`.
  *   - `static`: link statically (see above). Default `false`.
@@ -290,6 +291,15 @@ function assertSafeExtraInputPath(p, userObjPaths) {
  *   - `extraInputs`: absolute MEMFS path → bytes, written before ld runs.
  *     Use this to stage caller-supplied `.a` files / link scripts that
  *     `extraLibs` and `searchPaths` then resolve.
+ *   - `extraLdArgs`: raw `ld` flags spliced in right after the mode
+ *     switch (before `-L`/objects), for position-independent options the
+ *     wrapper has no dedicated knob for — e.g. canvas demos that pin a
+ *     framebuffer BSS section with `--section-start=.fb13h=0xA0000` and
+ *     keep it live with `--undefined=_fb13h_region`. Each entry is passed
+ *     to `ld` verbatim (one argv slot per array element, so write
+ *     `'--section-start=.fb13h=0xA0000'` as a single string, not two).
+ *     Defaults to `[]`, which leaves every existing link command — and
+ *     thus every byte-identical golden — unchanged.
  * @returns {Promise<Uint8Array>} ELF32 executable bytes
  */
 export async function link(objs, libs, opts = {}) {
@@ -300,6 +310,7 @@ export async function link(objs, libs, opts = {}) {
         extraLibs = [],
         searchPaths = [],
         extraInputs = {},
+        extraLdArgs = [],
     } = opts;
     assertSafeName(name, 'opts.name');
     const userObjs = normalizeObjs(objs, name);
@@ -310,6 +321,9 @@ export async function link(objs, libs, opts = {}) {
     }
     if (!Array.isArray(extraLibs) || !Array.isArray(searchPaths)) {
         throw new TypeError('extraLibs / searchPaths must be arrays');
+    }
+    if (!Array.isArray(extraLdArgs) || extraLdArgs.some(a => typeof a !== 'string')) {
+        throw new TypeError('extraLdArgs must be an array of strings');
     }
     if (typeof staticLink !== 'boolean') {
         throw new TypeError('opts.static must be boolean');
@@ -408,6 +422,7 @@ export async function link(objs, libs, opts = {}) {
     const cmd = [
         '-m', 'elf_i386', '--hash-style=gnu',
         ...modeArgs,
+        ...extraLdArgs,
         '-L/movfuscator', '-L/usr/lib32', '-L/lib32',
         ...searchPaths.map(p => `-L${p}`),
         ...headerLibArgs,

--- a/movfuscator-wasm/tests/run-static.mjs
+++ b/movfuscator-wasm/tests/run-static.mjs
@@ -543,21 +543,28 @@ await runTest('extraLdArgs splices --section-start / --undefined (byte-matches h
             `extraLdArgs ELF drift: wasm ${wasmElf.length} B vs host ${hostElf.length} B`,
         );
     }
-    // The section-start must actually have placed a PT_LOAD covering
-    // 0xA0000 — that's what lets movie86 pre-map the framebuffer.
+    // The section-start must actually have placed the framebuffer so
+    // that *some* PT_LOAD covers guest 0xA0000 — that's what lets
+    // movie86 pre-map it. The covering segment's VirtAddr is page-
+    // aligned *below* 0xA0000 (ld folds the ELF header + alignment in,
+    // so the real working canvas_mandelbrot.elf shows vaddr 0x9f000,
+    // MemSiz 0x3f800), with `.fb13h` itself landing at 0xA0000 inside
+    // it. So check range coverage, not an exact VirtAddr match.
     const dv = new DataView(wasmElf.buffer, wasmElf.byteOffset, wasmElf.byteLength);
     const phoff = dv.getUint32(28, true);
     const phentsize = dv.getUint16(42, true);
     const phnum = dv.getUint16(44, true);
+    const FB = 0xA0000;
     let foundFb = false;
     for (let i = 0; i < phnum; i++) {
         const base = phoff + i * phentsize;
         const ptype = dv.getUint32(base, true);
         const vaddr = dv.getUint32(base + 8, true);
-        if (ptype === 1 /* PT_LOAD */ && vaddr === 0xA0000) foundFb = true;
+        const memsz = dv.getUint32(base + 20, true);
+        if (ptype === 1 /* PT_LOAD */ && vaddr <= FB && FB < vaddr + memsz) foundFb = true;
     }
     if (!foundFb) {
-        throw new Error('no PT_LOAD at vaddr 0xA0000 — --section-start did not take effect');
+        throw new Error('no PT_LOAD covers guest 0xA0000 — --section-start did not take effect');
     }
 });
 

--- a/movfuscator-wasm/tests/run-static.mjs
+++ b/movfuscator-wasm/tests/run-static.mjs
@@ -473,6 +473,94 @@ await runTest('static-linked return42.elf reaches movfuscator SIGILL without pri
     );
 });
 
+// --- Test 6: extraLdArgs splices raw ld flags (byte-matches host) ---
+//
+// The explorer's canvas presets pin a framebuffer BSS section at the
+// mode-13h base (0xA0000) and keep it from being garbage-collected,
+// using two position-independent ld flags the wrapper has no dedicated
+// knob for:
+//
+//   --section-start=.fb13h=0xA0000   (place the section)
+//   --undefined=_fb13h_region        (retain its only symbol)
+//
+// `opts.extraLdArgs` passes them verbatim, spliced in right after the
+// mode switch (`-static`) and before `-L`/objects. This pins that
+// layout byte-for-byte against host /usr/bin/ld given the same flags —
+// the recipe `movie86/wasm/examples/sources/build-mandelbrot.sh` uses.
+const FB_STUB_S = `
+.text
+.globl _start
+_start:
+    movl $0, %ebx
+    movl $1, %eax
+    int $0x80
+
+.section .fb13h, "aw", @nobits
+.globl _fb13h_region
+_fb13h_region:
+.skip 256000
+`;
+
+await runTest('extraLdArgs splices --section-start / --undefined (byte-matches host)', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'movfuscator-extraldargs-'));
+    const sPath = join(tmp, 'fbstub.s');
+    const oPath = join(tmp, 'fbstub.o');
+    writeFileSync(sPath, FB_STUB_S);
+    const asRes = spawnSync('/usr/bin/as', [
+        '--32', '-mx86-used-note=no', '-o', oPath, sPath,
+    ], { encoding: 'buffer' });
+    if (asRes.status !== 0) {
+        throw new Error(`as failed: ${asRes.stderr?.toString() || ''}`);
+    }
+    const fbObj = readFileSync(oPath);
+
+    const ldArgs = ['--section-start=.fb13h=0xA0000', '--undefined=_fb13h_region'];
+    const wasmElf = await link(
+        { 'fbstub.o': new Uint8Array(fbObj) },
+        libs,
+        { static: true, runtime: 'none', extraLdArgs: ldArgs },
+    );
+
+    // Host baseline: same flags, same position (after `-static`, before
+    // `-L`/objects) so the byte comparison is meaningful.
+    const hostOut = join(tmp, 'out.elf');
+    const B = join(root, 'vendor/movfuscator/build');
+    const args = [
+        '-m', 'elf_i386', '--hash-style=gnu',
+        '-static',
+        ...ldArgs,
+        '-L', B, '-L', `${B}/gcc/32`, '-L', '/usr/lib32', '-L', '/lib32',
+        oPath,
+        '-o', hostOut,
+    ];
+    const res = spawnSync('/usr/bin/ld', args, { encoding: 'buffer' });
+    if (res.status !== 0) {
+        throw new Error(`host ld (extraLdArgs) failed: ${res.stderr?.toString() || ''}`);
+    }
+    const hostElf = readFileSync(hostOut);
+    if (!bytesEqual(wasmElf, hostElf)) {
+        throw new Error(
+            `extraLdArgs ELF drift: wasm ${wasmElf.length} B vs host ${hostElf.length} B`,
+        );
+    }
+    // The section-start must actually have placed a PT_LOAD covering
+    // 0xA0000 — that's what lets movie86 pre-map the framebuffer.
+    const dv = new DataView(wasmElf.buffer, wasmElf.byteOffset, wasmElf.byteLength);
+    const phoff = dv.getUint32(28, true);
+    const phentsize = dv.getUint16(42, true);
+    const phnum = dv.getUint16(44, true);
+    let foundFb = false;
+    for (let i = 0; i < phnum; i++) {
+        const base = phoff + i * phentsize;
+        const ptype = dv.getUint32(base, true);
+        const vaddr = dv.getUint32(base + 8, true);
+        if (ptype === 1 /* PT_LOAD */ && vaddr === 0xA0000) foundFb = true;
+    }
+    if (!foundFb) {
+        throw new Error('no PT_LOAD at vaddr 0xA0000 — --section-start did not take effect');
+    }
+});
+
 console.log();
 console.log(`results: ${pass} passed, ${fail} failed${skip ? `, ${skip} skipped` : ''}`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## 概要

explorer の選べる example が少なかったので、source preset menu に 3 つ追加しました。特に **mode-13h mandelbrot** は Canvas pane に実際に描画される初の preset です。

## 追加した preset

| id | 内容 | 走る場所 |
|---|---|---|
| `fizzbuzz` | 古典的な FizzBuzz 1..30 | Console (printf) |
| `fib` | 再帰フィボナッチ `fib(10) == 55` | status row (exit code) |
| `mandelbrot` | mode-13h フラクタル (固定小数 Q16.16, escape-time) | **Canvas pane** |

- `fib` をあえて再帰にしたのは、各 `call fib` が llvm-mov stage-7d3 の `CALL32d → JMP32d_CALL` 書き換えに乗るため。mov-only ターゲットが `call`/`ret` 無しでコールスタックを再現する様子が IR / asm pane で見えるのが、このプロジェクトらしい例になる(ループ版が速いがそれは隠れる)。
- `mandelbrot` は proven な coarse source(80×50 grid を 4×4 blit, `MAX_ITER=8`)。重い(guest 命令数百万・wall time 数分)が、それ自体が "mov-only emulator で本物の計算を回す" デモ。

## 仕組み: 宣言的 link profile

mandelbrot は source 文字列だけでは動かず、framebuffer を guest `0xA0000` に固定する必要があります。これを preset ごとの link recipe として導入しました。

- **explorer.mjs**: `LINK_PROFILES.canvas13h` を追加。mov-only ABI stubs(`set_video_mode` / `mmap_request` / `exit`)を組み込み、`.fb13h` BSS を `--section-start=.fb13h=0xA0000 --undefined=_fb13h_region` で VGA base に固定。**mov-only ABI asm は preset data ではなく explorer.mjs に置き、preset は純粋な source 文字列のまま**に保つ。
- **movfuscator-wasm `link()`**: 生の `ld` フラグを通す `extraLdArgs` を追加(`--section-start` / `--undefined` 用)。**default `[]` なので既存の byte-identical golden はすべて不変**。
- `Preset.linkProfile` を追加し、選択中の preset から compile opts へ伝播。

## movie86 は変更なし

embedded movie86 側は触っていません。`Canvas.tsx` が既に `vm.activeVideoMode` + framebuffer を読み、loader が `0xA0000` の PT_LOAD を pre-map し、AbiHost が `set_video_mode` 等を処理済みのため。

> [!NOTE]
> canvas preset が **実際に走るのは llvm-mov path のみ**です。movfuscator path は従来どおり外部シンボルが undefined dynamic symbol として残り、inspectable だが実行不可(既存の制約どおり)。

## テスト (TDD)

- **explorer unit** (`tests/unit.test.mjs`): `canvas13h` の配線(`stubs.o` が link inputs に入る・`--section-start`/`--undefined` が注入される)+ profile 無しの既定 path が最小のままという regression guard。→ **7/7 pass**、`tsc -b --noEmit` clean。
- **movfuscator-wasm** (`tests/run-static.mjs`): `extraLdArgs` が host `/usr/bin/ld` と byte 一致し、`0xA0000` に PT_LOAD が出ることを pin。→ wasm-ld build が要るため **CI gated**(ローカル未実行)。

full compile→run E2E は元々 sibling subproject の wasm artifact に依存し default では gate されない方針なので、ローカルでは unit + typecheck のみ確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)