### PR TITLE
turbo86: 起動時に SUPER INSECURE バナーを出す(TTY では赤)

### DIFF
--- a/turbo86/cmd/turbo86/main.go
+++ b/turbo86/cmd/turbo86/main.go
@@ -45,10 +45,35 @@ func main() {
 
 	patterns := parseOriginPatterns(*allowOrigin)
 
+	for _, line := range securityBanner() {
+		log.Print(line)
+	}
+
 	http.Handle("/", server.Handler(patterns))
 	log.Printf("turbo86 listening on ws://%s/ (allow-origin=%q)", *addr, *allowOrigin)
 	if err := http.ListenAndServe(*addr, nil); err != nil {
 		log.Fatalf("listen: %v", err)
+	}
+}
+
+// securityBanner returns the lines printed at startup. turbo86 hands
+// untrusted guest machine code straight to the host CPU and only
+// bridges syscalls via ptrace — there is no real sandbox in the
+// process itself (see DESIGN.md's threat model and PTRACE_O_EXITKILL
+// note). The banner exists so an operator can't miss that a stock
+// build must run in a disposable / isolated environment, never on a
+// box that matters. Returned as discrete lines so main() logs each
+// with a timestamp and the test can assert intent without pinning the
+// exact ASCII art.
+func securityBanner() []string {
+	return []string{
+		"================================================================",
+		"  turbo86 — *** SUPER INSECURE ***",
+		"  Executes UNTRUSTED guest machine code NATIVELY on this host's",
+		"  CPU. Syscalls are only ptrace-bridged; there is no in-process",
+		"  sandbox. Anything the guest does runs as YOU.",
+		"  Run ONLY in a disposable / sandboxed environment.",
+		"================================================================",
 	}
 }
 

--- a/turbo86/cmd/turbo86/main.go
+++ b/turbo86/cmd/turbo86/main.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -46,8 +47,11 @@ func main() {
 
 	patterns := parseOriginPatterns(*allowOrigin)
 
+	// Banner goes straight to stderr (not through log) so the
+	// per-line date/time prefix doesn't eat ~20 columns and wrap the
+	// art on narrow terminals. log still owns the "listening" line.
 	for _, line := range colorize(securityBanner(), isTerminal(os.Stderr)) {
-		log.Print(line)
+		fmt.Fprintln(os.Stderr, line)
 	}
 
 	http.Handle("/", server.Handler(patterns))
@@ -68,13 +72,14 @@ func main() {
 // exact ASCII art.
 func securityBanner() []string {
 	return []string{
-		"================================================================",
-		"  turbo86 — *** SUPER INSECURE REMOTE CODE EXECUTION PLATFORM ***",
-		"  Executes UNTRUSTED guest machine code NATIVELY on this host's",
-		"  CPU. Syscalls are only ptrace-bridged; there is no in-process",
-		"  sandbox. Anything the guest does runs as YOU.",
+		"============================================================",
+		"  turbo86 — *** SUPER INSECURE ***",
+		"  REMOTE CODE EXECUTION PLATFORM",
+		"  Runs UNTRUSTED guest machine code NATIVELY on this",
+		"  host's CPU as YOU. No in-process sandbox; syscalls",
+		"  are only ptrace-bridged.",
 		"  Run ONLY in a disposable / sandboxed environment.",
-		"================================================================",
+		"============================================================",
 	}
 }
 

--- a/turbo86/cmd/turbo86/main.go
+++ b/turbo86/cmd/turbo86/main.go
@@ -11,6 +11,7 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/sksat/x86.mov/turbo86/server"
@@ -45,7 +46,7 @@ func main() {
 
 	patterns := parseOriginPatterns(*allowOrigin)
 
-	for _, line := range securityBanner() {
+	for _, line := range colorize(securityBanner(), isTerminal(os.Stderr)) {
 		log.Print(line)
 	}
 
@@ -68,13 +69,53 @@ func main() {
 func securityBanner() []string {
 	return []string{
 		"================================================================",
-		"  turbo86 — *** SUPER INSECURE ***",
+		"  turbo86 — *** SUPER INSECURE REMOTE CODE EXECUTION PLATFORM ***",
 		"  Executes UNTRUSTED guest machine code NATIVELY on this host's",
 		"  CPU. Syscalls are only ptrace-bridged; there is no in-process",
 		"  sandbox. Anything the guest does runs as YOU.",
 		"  Run ONLY in a disposable / sandboxed environment.",
 		"================================================================",
 	}
+}
+
+// colorize wraps each non-empty banner line in bold-red ANSI when
+// enabled, resetting at the end of every line so an escape never
+// bleeds past its own line (log.Print prepends a timestamp, so the
+// reset has to be per-line, not once at the very end). When disabled
+// it returns the input untouched — that's exactly the bytes we want
+// in a redirected log file or a pipe, with no escape soup. The
+// caller decides "enabled" via isTerminal; keeping that probe out of
+// here makes the wrapping unit-testable.
+func colorize(lines []string, enabled bool) []string {
+	if !enabled {
+		return lines
+	}
+	const (
+		boldRed = "\x1b[1;31m"
+		reset   = "\x1b[0m"
+	)
+	out := make([]string, len(lines))
+	for i, line := range lines {
+		if line == "" {
+			out[i] = line
+			continue
+		}
+		out[i] = boldRed + line + reset
+	}
+	return out
+}
+
+// isTerminal reports whether f is attached to a terminal, so the
+// banner only emits ANSI color when a human is actually watching.
+// Using the file's mode (a character device) keeps this dependency-
+// free — pipes and regular files (`> log`, `| tee`) report false and
+// stay color-clean, which is the case that matters for logs.
+func isTerminal(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
 }
 
 // parseOriginPatterns splits a comma-separated pattern list, trimming

--- a/turbo86/cmd/turbo86/main_test.go
+++ b/turbo86/cmd/turbo86/main_test.go
@@ -22,9 +22,37 @@ func TestSecurityBanner(t *testing.T) {
 		t.Fatal("securityBanner() returned no lines")
 	}
 	joined := strings.ToLower(strings.Join(lines, "\n"))
-	for _, want := range []string{"super insecure", "untrusted", "nativ", "sandbox"} {
+	for _, want := range []string{"super insecure", "remote code execution", "untrusted", "nativ", "sandbox"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("securityBanner() missing %q; got:\n%s", want, strings.Join(lines, "\n"))
+		}
+	}
+}
+
+// TestColorize covers the TTY-only red policy. The function is pure
+// (takes an explicit enabled flag) so the I/O-bound TTY probe stays
+// out of the unit test. Disabled must return the lines untouched —
+// that's the bytes that land in a redirected log file; enabled wraps
+// each non-empty line in bold-red ANSI and resets, so escape codes
+// never leak across a line and a terminal renders the whole banner
+// red.
+func TestColorize(t *testing.T) {
+	in := []string{"a", "b"}
+
+	if got := colorize(in, false); !reflect.DeepEqual(got, in) {
+		t.Errorf("colorize(_, false) = %#v, want unchanged %#v", got, in)
+	}
+
+	got := colorize(in, true)
+	if len(got) != len(in) {
+		t.Fatalf("colorize(_, true) returned %d lines, want %d", len(got), len(in))
+	}
+	for i, line := range got {
+		if !strings.HasPrefix(line, "\x1b[1;31m") || !strings.HasSuffix(line, "\x1b[0m") {
+			t.Errorf("line %d not wrapped in bold-red+reset: %q", i, line)
+		}
+		if !strings.Contains(line, in[i]) {
+			t.Errorf("line %d lost its text %q: %q", i, in[i], line)
 		}
 	}
 }

--- a/turbo86/cmd/turbo86/main_test.go
+++ b/turbo86/cmd/turbo86/main_test.go
@@ -4,8 +4,30 @@ package main
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
+
+// TestSecurityBanner pins the startup warning. turbo86 executes
+// untrusted guest machine code natively on the host CPU (see
+// DESIGN.md threat model), so the banner has to scream that loudly
+// enough that nobody runs a stock build outside a sandbox by
+// accident. We assert intent, not the exact ASCII art: a non-empty
+// multi-line banner that names the danger ("SUPER INSECURE"), the
+// reason (untrusted code runs natively), and the mitigation (sandbox
+// only).
+func TestSecurityBanner(t *testing.T) {
+	lines := securityBanner()
+	if len(lines) == 0 {
+		t.Fatal("securityBanner() returned no lines")
+	}
+	joined := strings.ToLower(strings.Join(lines, "\n"))
+	for _, want := range []string{"super insecure", "untrusted", "nativ", "sandbox"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("securityBanner() missing %q; got:\n%s", want, strings.Join(lines, "\n"))
+		}
+	}
+}
 
 func TestParseOriginPatterns(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## 概要

turbo86 の起動時に、派手な **SUPER INSECURE** / **REMOTE CODE EXECUTION PLATFORM** 警告バナーをログへ出すようにしました。端末(TTY)に出力しているときは**太字赤**で目立たせます。

turbo86 はゲストの mov-only i386 機械語を**ホスト CPU でそのままネイティブ実行**し、syscall を ptrace で橋渡しするだけで、プロセス内サンドボックスは持ちません(DESIGN.md の脅威モデル / `PTRACE_O_EXITKILL` の項を参照)。ゲストの挙動はすべて起動ユーザ権限で動くため、素のビルドを「大事なマシン」でうっかり起動してしまうのを防ぐべく、起動時に見逃せない形で警告を出します。

## 起動ログ

```
============================================================
  turbo86 — *** SUPER INSECURE ***
  REMOTE CODE EXECUTION PLATFORM
  Runs UNTRUSTED guest machine code NATIVELY on this
  host's CPU as YOU. No in-process sandbox; syscalls
  are only ptrace-bridged.
  Run ONLY in a disposable / sandboxed environment.
============================================================
2026/.../... turbo86 listening on ws://127.0.0.1:1234/ (allow-origin=...)
```

端末では全体が太字赤(`\x1b[1;31m`)で表示されます。

## 実装

- 警告文言を `securityBanner() []string` に切り出し、横幅 **60桁**・`SUPER INSECURE` と `REMOTE CODE EXECUTION PLATFORM` を別行に整形。
- バナーは `log` を介さず `fmt.Fprintln(os.Stderr, ...)` で直接出力。`log.Print` が各行頭に付ける `date time ` 前置(約20桁)を省き、狭い端末でも折り返さないようにしています。`listening...` 行は従来どおり `log` でタイムスタンプ付き。
- 色付けは純粋関数 `colorize(lines, enabled)` に分離。有効時は各**非空行**を太字赤 ANSI で囲み、**行ごとに reset**。
- TTY 判定 `isTerminal()` は `os.Stderr` のファイルモード(`ModeCharDevice`)を見るだけで**依存追加なし**。パイプやリダイレクト(`> log`、`| tee`)では非端末と判定され、ログにエスケープが残りません。
- I/O 依存の TTY 判定を `colorize` の外に出すことで、色付けロジックを端末なしでユニットテストできます。

## テスト (TDD)

リポジトリの TDD 規約に従い、先に失敗するテストを追加してから実装(赤→緑)。

- `TestSecurityBanner`: 文言の意図(super insecure / remote code execution / untrusted / native / sandbox)を検証。罫線などの見た目には依存しない。
- `TestColorize`: 無効時は入力をそのまま返す / 有効時は各行が太字赤+reset で囲まれ元テキストを保持する、を検証。
- `go test ./cmd/turbo86/` ✅ / `go vet` ✅ / `go build` ✅
- 擬似端末(`script`)で60桁・赤表示、パイプでプレーン出力を目視確認 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)