### PR TITLE
movie86: jmp rel8 (EB) をデコードする

### DIFF
--- a/movie86/core/src/cpu.rs
+++ b/movie86/core/src/cpu.rs
@@ -152,6 +152,13 @@ impl Cpu {
                 let off_bits = u32::from_ne_bytes(off.to_ne_bytes());
                 Ok(next_eip_default.wrapping_add(off_bits))
             }
+            Insn::JmpRel8(off) => {
+                // Same as JmpRel32 but with the 8-bit displacement
+                // sign-extended; relative to the next instruction (the
+                // address right after the 2-byte EB jmp).
+                let off_bits = u32::from_ne_bytes(i32::from(off).to_ne_bytes());
+                Ok(next_eip_default.wrapping_add(off_bits))
+            }
             Insn::Int(0x80) => {
                 let args = SyscallArgs::from_regs(&self.regs);
                 match host.syscall(&args, mem)? {
@@ -922,6 +929,27 @@ mod tests {
         let mut cpu = Cpu::new(0x1005);
         cpu.step(&mut mem, &mut PanicHost).unwrap();
         assert_eq!(cpu.eip, 0x1000);
+    }
+
+    #[test]
+    fn step_jmp_rel8_targets_eip_relative_to_next_insn() {
+        // 1000: eb 0a   → jmp +10
+        // Next-insn address is 0x1002; target is 0x1002 + 10 = 0x100c.
+        let mut mem = FlatMemory::new_zeroed(0x1000, 0x100);
+        mem.write_bytes(0x1000, &[0xeb, 0x0a]).unwrap();
+        let mut cpu = Cpu::new(0x1000);
+        cpu.step(&mut mem, &mut PanicHost).unwrap();
+        assert_eq!(cpu.eip, 0x100c);
+    }
+
+    #[test]
+    fn step_jmp_rel8_negative_loops_back() {
+        // 1005: eb fe  → jmp -2  (next-insn is 0x1007; target 0x1005 — self-loop)
+        let mut mem = FlatMemory::new_zeroed(0x1000, 0x100);
+        mem.write_bytes(0x1005, &[0xeb, 0xfe]).unwrap();
+        let mut cpu = Cpu::new(0x1005);
+        cpu.step(&mut mem, &mut PanicHost).unwrap();
+        assert_eq!(cpu.eip, 0x1005);
     }
 
     #[test]

--- a/movie86/core/src/decode.rs
+++ b/movie86/core/src/decode.rs
@@ -70,6 +70,11 @@ pub fn decode(bytes: &[u8]) -> Result<(Insn, u8), Fault> {
             let off = read_i32_le(rest, 1)?;
             (Insn::JmpRel32(off), 5)
         }
+        // jmp rel8 — opcode EB cb (short form the assembler relaxes to)
+        (false, 0xEB) => {
+            let off = i8::from_ne_bytes([*rest.get(1).ok_or(Fault::DecodeTruncated)?]);
+            (Insn::JmpRel8(off), 2)
+        }
         // int imm8 — opcode CD ib
         (false, 0xCD) => {
             let n = *rest.get(1).ok_or(Fault::DecodeTruncated)?;
@@ -912,6 +917,24 @@ mod tests {
         // e9 fb ff ff ff → jmp -5 (i.e. an infinite loop on a 5-byte jmp)
         let (insn, _) = decode(&[0xe9, 0xfb, 0xff, 0xff, 0xff]).unwrap();
         assert_eq!(insn, Insn::JmpRel32(-5));
+    }
+
+    #[test]
+    fn jmp_rel8_positive() {
+        // eb 05 → jmp +5 (short form). The assembler relaxes in-range
+        // `jmp label` to this 2-byte EB form; llvm-mov-generated mov-only
+        // ELFs hit it on the dispatcher jumps, so movie86 must decode it.
+        let (insn, len) = decode(&[0xeb, 0x05]).unwrap();
+        assert_eq!(len, 2);
+        assert_eq!(insn, Insn::JmpRel8(5));
+    }
+
+    #[test]
+    fn jmp_rel8_negative_disp() {
+        // eb fe → jmp -2 (a 2-byte self-loop).
+        let (insn, len) = decode(&[0xeb, 0xfe]).unwrap();
+        assert_eq!(len, 2);
+        assert_eq!(insn, Insn::JmpRel8(-2));
     }
 
     #[test]

--- a/movie86/core/src/insn.rs
+++ b/movie86/core/src/insn.rs
@@ -182,6 +182,13 @@ pub enum Insn {
     /// `jmp rel32` (opcode `E9 cd`) — unconditional near jump. The
     /// displacement is added to the address of the **next** instruction.
     JmpRel32(i32),
+    /// `jmp rel8` (opcode `EB cb`) — short unconditional jump, an 8-bit
+    /// signed displacement from the next instruction. Same semantics as
+    /// [`Insn::JmpRel32`], just the encoding the assembler picks when a
+    /// `jmp label` target is within `rel8` range. mov-only output from
+    /// llvm-mov hits this on its dispatcher jumps (gas relaxes them to
+    /// the 2-byte EB form), so the emulator has to decode both widths.
+    JmpRel8(i8),
     /// `int n` (opcode `CD ib`) — software interrupt. Only `int 0x80`
     /// (Linux syscall) is wired to a handler; other vectors trap.
     Int(u8),
@@ -382,6 +389,10 @@ impl core::fmt::Display for Insn {
             Self::JmpRel32(off) => {
                 f.write_str("jmp ")?;
                 fmt_rel(f, *off)
+            }
+            Self::JmpRel8(off) => {
+                f.write_str("jmp ")?;
+                fmt_rel(f, i32::from(*off))
             }
             Self::CallRel32(off) => {
                 f.write_str("call ")?;


### PR DESCRIPTION
## 概要

movie86 のデコーダは `jmp` の near 形(`E9` rel32)と間接形(`FF /4`, reg/mem)は解せたが、**短縮形 `jmp rel8`(`EB cb`)を知らず `UnknownOpcode(0xEB)` で停止**していた。

アセンブラ(gas / llvm-mc)は in-range の `jmp label` を 2 バイトの `EB` に relax する。そのため **llvm-mov が吐く mov-only ELF はディスパッチャ jmp に `EB` を含む**。これを movie86 で実行(= SIMD86 デックのブラウザプレビュー)するには `EB` の解読が必須。

## 背景(なぜ obj 直出力ではなくデコーダ側で直すか)

`.s → gas` を経由する限り、どの標準アセンブラも in-range jmp を短縮形に relax するので `EB` は避けられない。`llvm-mov-llc -filetype=obj` で回避しようとしたが、**Mov ターゲットは MCCodeEmitter / AsmBackend を持たず**(AsmPrinter のみ)、オブジェクト直出力には MC レイヤの実装(命令→機械語符号化 + リロケーション)という大仕事が必要だった。一方 `EB` のデコードは既存 `jmp` のエンコード補完で済み、あらゆる llvm-mov / gas 出力に効く。新しい「非 mov 命令」を足すものではない。

## 変更点

- `insn.rs`: `Insn::JmpRel8(i8)` を追加(`JmpRel32` と同じ意味、8bit 符号付き変位)。
- `decode.rs`: `(false, 0xEB)` を 2 バイトで decode。
- `cpu.rs`: 変位を符号拡張して次命令アドレスに加算(`JmpRel32` と同じ実行パス)。

## テスト

- decode ユニットテスト 2 本(正 `eb 05` / 負 `eb fe`)。
- executor テスト 2 本(`jmp +10` / `jmp -2` 自己ループ)。
- `cargo fmt` / `clippy`(`-D warnings`)クリーン、workspace 全テスト green、`wasm32-unknown-unknown` ビルド可。
- e2e: llvm-mov 製 SIMD86 デックが movie86 上で Right/Left/Home でスライド遷移するのを確認(EB 解読前は `UnknownOpcode(0xEB)` で停止していた)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)