### PR TITLE
movie86: ハンドオーバー中のキー入力を turbo86 へ WS 転送する

### DIFF
--- a/movie86/wasm/index.html
+++ b/movie86/wasm/index.html
@@ -342,6 +342,7 @@ import {
     snapshotContext,
     loadContextInto,
     makeLoadContextMessage,
+    makeKeyInputMessage,
     parseOutboundMessage,
     attachKeyboard,
 } from './movie86.mjs';
@@ -445,15 +446,32 @@ async function fetchExample(name) {
     return new Uint8Array(await r.arrayBuffer());
 }
 
+// Keyboard sink shared by attachKeyboard: forward to turbo86 over the WS
+// while a session is handed off there, else into the local Vm. Reads the
+// live engine/ws each call so it follows the engine flip without
+// re-attaching the listener.
+function routeKeyToEngine(code) {
+    if (state.engine === 'turbo86' && turbo86.ws && turbo86.ws.readyState === WebSocket.OPEN) {
+        turbo86.ws.send(makeKeyInputMessage(code));
+        return;
+    }
+    state.vm?.pushInput(code);
+}
+
 async function loadFromBytes(bytes, label) {
     if (state.detachKeyboard) { state.detachKeyboard(); state.detachKeyboard = null; }
     if (state.vm) { state.vm.free(); state.vm = null; }
     state.elfBytes = bytes;
     state.vm = await loadVm(bytes);
-    // Route keyboard into the guest's input queue, but only while the
-    // pointer is over the canvas area — off-canvas keystrokes stay with
-    // the page. Examples that never poll just never drain the queue.
-    state.detachKeyboard = attachKeyboard(state.vm, $('canvases'));
+    // Route keyboard input to whichever engine is live: while a session
+    // is handed off to turbo86, keys go over the WS as proto.KeyInput so
+    // the native guest's CALL_POLL_INPUT reads them; otherwise into the
+    // local Vm's queue. Either way only while the pointer is over the
+    // canvas area — off-canvas keystrokes stay with the page. Examples
+    // that never poll just never drain the queue. The sink is stable;
+    // it reads `state.engine` / `turbo86.ws` live so the same handler
+    // follows the engine flip without re-attaching.
+    state.detachKeyboard = attachKeyboard(routeKeyToEngine, $('canvases'));
     state.prevRegs = null;
     state.prevEip = null;
     state.stdoutBuf = '';

--- a/movie86/wasm/movie86.mjs
+++ b/movie86/wasm/movie86.mjs
@@ -161,7 +161,15 @@ export function keyEventToCode(e) {
  * @param {Document|Window} [opts.target=window]  Where to bind keydown.
  * @returns {() => void}  Detach function removing all listeners.
  */
-export function attachKeyboard(vm, hoverEl, opts = {}) {
+export function attachKeyboard(vmOrSink, hoverEl, opts = {}) {
+    // First arg is either a Vm (push straight into its local input queue)
+    // or a sink `(code) => void` — the latter lets the caller route keys
+    // elsewhere, e.g. forward them to turbo86 over the WS as proto.KeyInput
+    // while a session is handed off. Keeps the original `(vm, hoverEl)`
+    // call working unchanged.
+    const push = typeof vmOrSink === 'function'
+        ? vmOrSink
+        : (code) => vmOrSink.pushInput(code);
     const target = opts.target ?? window;
     let hovered = false;
 
@@ -172,7 +180,7 @@ export function attachKeyboard(vm, hoverEl, opts = {}) {
         const code = keyEventToCode(e);
         if (code === null) return;
         if (SCROLL_KEYS.has(code)) e.preventDefault();
-        vm.pushInput(code);
+        push(code);
     };
 
     hoverEl.addEventListener('pointerenter', onEnter);
@@ -363,6 +371,21 @@ function base64ToBytes(b64) {
  * @param {number} [memUpdateIntervalMs=0]
  * @returns {string} JSON-encoded frame, ready for WebSocket.send().
  */
+/**
+ * Wire frame for one key input forwarded to a running turbo86 session,
+ * matching `proto.KeyInput` (`{type:"key_input", code}`). The frontend
+ * sends this over the WS while engine == 'turbo86' so the guest's
+ * mov-only `CALL_POLL_INPUT` reads it — the same byte the local Vm
+ * would see via `vm.pushInput`, so a deck/game behaves identically
+ * before and after the handover.
+ *
+ * @param {number} code  a movie86 KEY_* code (0..255)
+ * @returns {string} JSON wire frame
+ */
+export function makeKeyInputMessage(code) {
+    return JSON.stringify({ type: 'key_input', code: code & 0xff });
+}
+
 export function makeLoadContextMessage(ctx, mode = 'host', memUpdateIntervalMs = 0) {
     const msg = {
         type: 'load_context',

--- a/movie86/wasm/tests/turbo86_handover.mjs
+++ b/movie86/wasm/tests/turbo86_handover.mjs
@@ -348,6 +348,54 @@ async function main() {
             failed++;
         }
 
+        // KeyInput path: forward a key over the WS as proto.KeyInput —
+        // the exact frame the browser sends in turbo86 mode
+        // (makeKeyInputMessage) — and assert the guest's mov-only
+        // CALL_POLL_INPUT reads it. The guest busy-polls until it gets a
+        // non-zero code, then exits with it, so the key can arrive any
+        // time after LoadContext without a race. This pins the browser →
+        // turbo86 keyboard half end-to-end against a real turbo86 (the
+        // runner side is unit-tested in runner/abi_test.go).
+        try {
+            const entry = 0x08048000;
+            const KEY_RIGHT = 0x81; // movie86 KEY_RIGHT
+            // poll: mov [0x1FFE0040],al ; test eax,eax ; jz poll ;
+            //       mov [0x1FFE00FE],eax  (exit with the polled key).
+            // jz rel8 = -9 loops back to poll until a non-zero key.
+            const code = new Uint8Array([
+                0xA2, 0x40, 0x00, 0xFE, 0x1F, // poll → eax
+                0x85, 0xC0,                   // test eax, eax
+                0x74, 0xF7,                   // jz poll (-9)
+                0xA3, 0xFE, 0x00, 0xFE, 0x1F, // exit(eax)
+            ]);
+            const keyCtx = {
+                regs: { ...ctx.regs, eip: entry },
+                regions: [{ addr: entry, bytes: code }],
+            };
+            const url = `ws://127.0.0.1:${port}/`;
+            const ws = new WebSocket(url);
+            const events = [];
+            await new Promise((resolve, reject) => {
+                ws.addEventListener('open', () => {
+                    ws.send(wrapper.makeLoadContextMessage(keyCtx, 'host'));
+                    // Forward the key the same way the browser does in
+                    // turbo86 mode; the guest is spinning on poll by now.
+                    setTimeout(() => ws.send(wrapper.makeKeyInputMessage(KEY_RIGHT)), 100);
+                }, { once: true });
+                ws.addEventListener('message', (e) => events.push(wrapper.parseOutboundMessage(e.data)));
+                ws.addEventListener('close', resolve, { once: true });
+                ws.addEventListener('error', reject, { once: true });
+            });
+            const exit = events.find(e => e.type === 'exit');
+            assert.ok(exit, `no exit event in ${events.length} events`);
+            assert.equal(exit.code, KEY_RIGHT,
+                `exit ${exit.code} != forwarded key ${KEY_RIGHT} — KeyInput didn't reach the guest`);
+            console.log('ok  real turbo86 KeyInput (forward key → poll → exit(key))');
+        } catch (e) {
+            console.error(`FAIL real turbo86 KeyInput: ${e.stack || e.message}`);
+            failed++;
+        }
+
         // VideoMode Outbound + setActiveVideoMode round-trip. This is
         // the canvas-rendering path: turbo86 catches a `mov [ABI+0x010],
         // al` (CALL_SET_VIDEO_MODE) and emits a VideoMode event; the


### PR DESCRIPTION
## 概要

#63 で turbo86 は WS の `proto.KeyInput` を受け取れるようになったが、**フロントエンド側がキーを送っていなかった**ため、turbo86 にハンドオーバーすると入力が効かなかった(guest の `CALL_POLL_INPUT` が `KEY_NONE` を読み続ける)。「プロセスは止まらないが input が動かない」の原因。

本 PR でブラウザ → turbo86 のキー転送を配線し、**実機 turbo86 で end-to-end 検証**した。

> ⚠️ base は #63(`turbo86/ws-key-input`)。turbo86 側の KeyInput 受信に依存し、E2E テストもそれを前提にする。

## 変更点

- **movie86.mjs**: `makeKeyInputMessage(code)` を追加(`proto.KeyInput` のワイヤ形 `{type:"key_input",code}`、`makeLoadContextMessage` と同系統)。`attachKeyboard` の第1引数を **「Vm または sink 関数」両対応**に(後方互換 — 既存の `attachKeyboard(vm, hoverEl)` はそのまま)。
- **index.html**: keydown sink を `routeKeyToEngine` に。`engine == 'turbo86'` かつ WS open なら `makeKeyInputMessage` を WS 送信、そうでなければローカル Vm の `pushInput`。sink は `state.engine` / `turbo86.ws` をライブ参照するので、エンジン切替でリスナを再アタッチ不要。

## E2E テスト + 検証

`tests/turbo86_handover.mjs` に **KeyInput ケース**を追加(実機 turbo86 を go build して起動):

- poll ループ guest(`mov [ABI+0x040],al ; test eax,eax ; jz poll ; exit(eax)`)をハンドオーバー。
- `makeKeyInputMessage(KEY_RIGHT=0x81)` を WS 送信。
- guest の poll が 0x81 を読み `Exit{code:0x81}` を確認。

実行結果(全 handover E2E + 回帰):
```
ok  real turbo86 KeyInput (forward key → poll → exit(key))
ok  real turbo86 handover (exit 42 / write / VideoMode / MemUpdate / Reservation / round-trip)
all smoke tests passed / input_demo e2e / runloop tests passed
```

## これで可能になること

turbo86 ハンドオーバー後、canvas hover 中の ← → / Space などが guest に届く。SIMD86 デック(#76)の「アクセラレーションブースト」(turbo86 ネイティブ速度でのスライド遷移)の前提が揃う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)