### PR TITLE
llvm-mov/wasm: rsHostToIR — host rustc bypass (Node-only)

### DIFF
--- a/llvm-mov/wasm/CLAUDE.md
+++ b/llvm-mov/wasm/CLAUDE.md
@@ -52,6 +52,10 @@ Three things shape every decision here:
 .rs ──rustc.wasm──→ .ll  ─┘   (in progress — see "Rust frontend" below)
     │
     └→ rsToIR()
+
+.rs ──host rustc──→ .ll  ─┘   (Node-only bypass — see "host bypass" below)
+    │
+    └→ rsHostToIR()
 ```
 
 - **clang.wasm**: a standalone clang driver, statically linked against
@@ -138,6 +142,7 @@ then throws an install-hint error.
 | Smoke test (`tests/run-rust.sh`) | ✅ green on `ret_42.rs` (rubrc v0.2.0) | extend fixture set |
 | `'self-bjorn3-wasm20'` registry row (Rust 1.96 / i686 / edition 2024) | ✅ slot defined; `scripts/build-wasm-rustc.sh` documented | run the script — multi-hour build |
 | Browser driver (`@oligami/rustc-browser-wasi_shim` + WASIFarm) | not started | mirror Node driver's shape for the explorer page |
+| Host-rustc bypass (`rsHostToIR` + `tests/run-rust-host.sh`) | ✅ landed (Node-only) | wire into explorer through a backend service or as a Node-side build step |
 | Explorer UI integration | not started | dropdown + dynamic-import in `explorer/src/lib/wrappers.ts` |
 
 ### Self-hosted artefact (`scripts/build-wasm-rustc.sh`)
@@ -185,6 +190,47 @@ The first-cut artefact only ships sysroots for `wasm32-wasip1` and
 `llvm-mov-llc.wasm` will fail until we land a self-hosted artefact
 with an `i686` sysroot. The `rsToIR` half is complete; the join with
 `compile()` is what's gated on the next artefact.
+
+## Rust frontend (host bypass)
+
+`rsHostToIR(source)` runs the host `rustc` as a subprocess and returns
+LLVM IR text. Same I/O shape as `rsToIR()` but no wasm artefact is
+needed — works today, on the dev box, for any `--target` that
+`rustup target add` has installed.
+
+The point of this path: until the in-wasm rustc story (`rsToIR`
+above) ships an i686-aware artefact, `rsHostToIR(..., { target:
+'i686-unknown-linux-gnu' })` is the way to get IR that
+`compile()` (wasm llvm-mov-llc) actually accepts after the usual
+`mtriple: 'mov-unknown-linux-gnu'` override — i.e. the explorer can
+expose a working Rust path *now* by sticking host-emitted IR into the
+same `.ll → .s → .o → ELF32` wasm tail the C path uses.
+
+Trade-off: Node-only by construction (spawns a subprocess + touches
+the filesystem). A browser-side bypass would need a backend service
+(e.g. a tiny `compile-server` over WebSocket that returns the IR).
+
+```js
+import { rsHostToIR, compile } from './llvm-mov.mjs';
+
+const src = `#![no_std]
+    #[panic_handler] fn p(_:&core::panic::PanicInfo)->!{loop{}}
+    #[unsafe(no_mangle)] pub extern "C" fn rust_main() -> i32 { 42 }`;
+
+const ir  = await rsHostToIR(src);  // i686-unknown-linux-gnu IR
+const asm = await compile(ir, { mtriple: 'mov-unknown-linux-gnu' });
+// → mov-target x86-32 GAS asm; ready for as.wasm / ld.wasm.
+```
+
+Prereq on the host:
+```
+rustup target add i686-unknown-linux-gnu
+```
+
+Smoke gate: [`tests/run-rust-host.sh`](tests/run-rust-host.sh) (=
+`make test-rust-host`). Asserts `rsHostToIR(host_ret_42.rs)` returns
+IR containing `define … @rust_main(`. Independent of the wasm rustc
+artefact, so doesn't need `wasmtime`.
 
 ## Build graph
 

--- a/llvm-mov/wasm/Makefile
+++ b/llvm-mov/wasm/Makefile
@@ -11,7 +11,7 @@ BUILD_DIR     ?= build
 .PHONY: help setup build build-wasm-llvm build-wasm-clang \
         build-wasm-llvm-mov-llc build-native-llvm-mov-llc \
         build-wasm-rustc \
-        test test-rust test-e2e test-e2e-dist test-e2e-dist-fzstd \
+        test test-rust test-rust-host test-e2e test-e2e-dist test-e2e-dist-fzstd \
         stage-deploy serve clean distclean
 
 help:
@@ -25,6 +25,8 @@ help:
 	@echo "  build-wasm-rustc            self-host rustc.wasm from bjorn3/rust wasm20 (multi-hour;"
 	@echo "                              populates 'self-bjorn3-wasm20' row in RUSTC_VERSIONS)"
 	@echo "  test                        parity test: wasm .s vs native .s (per fixture)"
+	@echo "  test-rust                   smoke: rsToIR() via wasm rustc (rubrc artefact, needs wasmtime)"
+	@echo "  test-rust-host              smoke: rsHostToIR() via host rustc (i686 target, no wasm)"
 	@echo "  test-e2e                    playwright: drive the demo page in a headless browser"
 	@echo "                              and diff the rendered .s against native (needs npm + browsers)"
 	@echo "  test-e2e-dist               same as test-e2e but against the staged ../../dist/ via a"
@@ -86,6 +88,14 @@ test: build
 # See ../CLAUDE.md "Rust frontend (in progress)" §.
 test-rust:
 	./tests/run-rust.sh
+
+# Host-rustc bypass smoke. Drives the host `rustc` through
+# `rsHostToIR()` — works today, needs `rustup target add
+# i686-unknown-linux-gnu` and nothing else. The wasm bypass while the
+# in-wasm rustc story stabilises.
+# See ../CLAUDE.md "Rust frontend (host bypass)" §.
+test-rust-host:
+	./tests/run-rust-host.sh
 
 # Self-host rustc.wasm from bjorn3/rust:compile_rustc_for_wasm20.
 # Multi-hour build. See scripts/build-wasm-rustc.sh header for

--- a/llvm-mov/wasm/lib/rustc-host-driver.mjs
+++ b/llvm-mov/wasm/lib/rustc-host-driver.mjs
@@ -1,0 +1,76 @@
+// rustc-host-driver.mjs
+//
+// Drives the *host* `rustc` (whatever's on $PATH or pointed at by
+// `opts.rustc`) as a subprocess and returns LLVM IR text. The sibling
+// `rustc-driver.mjs` drives a wasm-hosted rustc through wasmtime; this
+// one trades "everything in wasm" for "works today, with the host's
+// rustup target add" — useful as the explorer's Rust-frontend bypass
+// while the in-wasm rustc story is still pending an i686-aware artefact
+// (see ../CLAUDE.md "Rust frontend (in progress)" §).
+//
+// Node-only by construction (subprocess + filesystem). A browser-side
+// driver would need a server endpoint or a wasm rustc — neither is in
+// scope here.
+
+import { spawn } from 'node:child_process';
+import { promises as fsp } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+export async function rsHostToIRImpl(source, opts) {
+    const rustc = opts.rustc ?? process.env.RUSTC ?? 'rustc';
+    const target = opts.target ?? 'i686-unknown-linux-gnu';
+    const edition = opts.edition ?? '2024';
+    const crateType = opts.crateType ?? 'lib';
+    const optLevel = opts.optLevel ?? '2';
+
+    const runDir = await fsp.mkdtemp(path.join(tmpdir(), 'rs-host-'));
+    try {
+        // Use a stable basename. rustc bakes the crate name (= file
+        // basename minus `.rs`) into the IR's source_filename and into
+        // the emitted `<name>.ll` filename, so picking it explicitly
+        // makes the output path predictable for the read-back below.
+        const stem = (opts.name ?? 'in.rs').replace(/\.rs$/, '');
+        const srcPath = path.join(runDir, `${stem}.rs`);
+        await fsp.writeFile(srcPath, source);
+
+        const args = [
+            `--edition=${edition}`,
+            `--crate-type=${crateType}`,
+            `--target=${target}`,
+            '--emit=llvm-ir',
+            '-C', 'panic=abort',
+            '-C', 'overflow-checks=false',
+            '-C', `opt-level=${optLevel}`,
+            '-C', 'debuginfo=0',
+            '-C', 'strip=symbols',
+            ...(opts.rustcFlags ?? []),
+            srcPath,
+            '--out-dir', runDir,
+        ];
+
+        opts.onProgress?.({ stage: 'run-host-rustc' });
+        const stderrChunks = [];
+        await new Promise((resolve, reject) => {
+            const child = spawn(rustc, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+            child.on('error', reject);
+            child.stdout.on('data', () => {});                // silence
+            child.stderr.on('data', (d) => stderrChunks.push(d));
+            child.on('exit', (code) => {
+                const stderr = Buffer.concat(stderrChunks).toString('utf8');
+                if (code !== 0) {
+                    reject(new Error(
+                        `host rustc exited ${code} (target=${target}, edition=${edition}):\n${stderr}`,
+                    ));
+                } else {
+                    resolve();
+                }
+            });
+        });
+
+        const llPath = path.join(runDir, `${stem}.ll`);
+        return await fsp.readFile(llPath, 'utf8');
+    } finally {
+        await fsp.rm(runDir, { recursive: true, force: true }).catch(() => {});
+    }
+}

--- a/llvm-mov/wasm/llvm-mov.d.ts
+++ b/llvm-mov/wasm/llvm-mov.d.ts
@@ -30,7 +30,9 @@ export type ProgressEvent =
     // files in build/rustc-cache/<versionKey>/ short-circuit them).
     | { stage: 'fetch-rustc' }
     | { stage: 'fetch-sysroot' }
-    | { stage: 'run-rustc' };
+    | { stage: 'run-rustc' }
+    // Host-rustc bypass (rsHostToIR) stage.
+    | { stage: 'run-host-rustc' };
 
 export type ProgressCallback = (ev: ProgressEvent) => void;
 
@@ -168,3 +170,38 @@ export interface RsToIROptions {
  * `wasm32-wasip1` output won't lower without an i686 sysroot artefact.
  */
 export function rsToIR(source: string, opts?: RsToIROptions): Promise<string>;
+
+export interface RsHostToIROptions {
+    /** Basename for the source file written to a tempdir. Defaults to `in.rs`. */
+    name?: string;
+    /** Explicit rustc binary. Falls back to `$RUSTC` then `rustc` on PATH. */
+    rustc?: string;
+    /**
+     * `--target`. Defaults to `i686-unknown-linux-gnu` — the one
+     * `llvm-mov-llc` accepts (with an `mtriple` override). Requires
+     * `rustup target add <target>` on the host.
+     */
+    target?: string;
+    /** `--edition`. Defaults to `2024`. */
+    edition?: '2015' | '2018' | '2021' | '2024';
+    /** `--crate-type`. Defaults to `lib`. */
+    crateType?: 'lib' | 'staticlib' | 'cdylib' | 'rlib';
+    /** `-C opt-level=…`. Defaults to `'2'`. */
+    optLevel?: OptLevel;
+    /** Appended verbatim to the rustc command line. */
+    rustcFlags?: string[];
+    /** Status callback; see ProgressEvent for the stage sequence. */
+    onProgress?: ProgressCallback;
+}
+
+/**
+ * Compile a single Rust source file to LLVM IR text via the host
+ * `rustc`. Node-only — spawns a subprocess. Use as the explorer's
+ * Rust-frontend bypass while the in-wasm path (rsToIR) catches up.
+ *
+ * The emitted IR is compatible with `compile()`'s `mtriple` override
+ * exactly like clang-produced IR, so the wasm tail
+ * (`llvm-mov-llc.wasm → as.wasm → ld.wasm`) accepts it without
+ * needing the i686-aware rustc.wasm artefact.
+ */
+export function rsHostToIR(source: string, opts?: RsHostToIROptions): Promise<string>;

--- a/llvm-mov/wasm/llvm-mov.mjs
+++ b/llvm-mov/wasm/llvm-mov.mjs
@@ -519,3 +519,70 @@ export async function rsToIR(source, opts = {}) {
         artefacts: { ...spec.artefacts, ...(opts.artefacts ?? {}) },
     });
 }
+
+// ---------------------------------------------------------------------------
+// Rust frontend — host bypass
+// ---------------------------------------------------------------------------
+//
+// `rsHostToIR(source)` spawns the host `rustc` (whatever's on $PATH /
+// $RUSTC / opts.rustc) and returns LLVM IR text. Same shape as
+// `rsToIR()` but uses the host toolchain instead of a wasm artefact,
+// which means it works *today* for any target `rustup target add`
+// has installed (notably `i686-unknown-linux-gnu` — the one
+// `llvm-mov-llc.wasm` actually accepts).
+//
+// Use this as the explorer's Rust-frontend bypass while the in-wasm
+// rustc path (rsToIR) catches up. Node-only by construction; a
+// browser-side counterpart would need a backend service or the wasm
+// path. See `../CLAUDE.md` "Rust frontend (host bypass)" §.
+
+let _rustcHostDriver = null;
+async function loadRustcHostDriver() {
+    if (_rustcHostDriver === null) {
+        const m = await import('./lib/rustc-host-driver.mjs');
+        _rustcHostDriver = m.rsHostToIRImpl;
+    }
+    return _rustcHostDriver;
+}
+
+/**
+ * Compile a single Rust source file to LLVM IR text via the host
+ * `rustc`. The Node-side counterpart to `rsToIR` — same input/output
+ * shape but driven by a subprocess to whatever rustc is on $PATH.
+ *
+ * @param {string} source Rust source text.
+ * @param {{
+ *     name?: string,
+ *     rustc?: string,
+ *     target?: string,
+ *     edition?: '2015'|'2018'|'2021'|'2024',
+ *     crateType?: 'lib'|'staticlib'|'cdylib'|'rlib',
+ *     optLevel?: '0'|'1'|'2'|'3'|'s'|'z',
+ *     rustcFlags?: string[],
+ *     onProgress?: (ev: { stage: string }) => void,
+ * }} [opts]
+ *   - `name`: MEMFS basename for the source file. Defaults to `in.rs`.
+ *     rustc bakes the stem into `source_filename` and the output
+ *     `<stem>.ll` filename, so pick deliberately if downstream parity
+ *     matters.
+ *   - `rustc`: explicit binary path. Falls back to `$RUSTC` then `rustc`.
+ *   - `target`: `--target`. Defaults to `i686-unknown-linux-gnu`
+ *     (the one `llvm-mov-llc` accepts after `mtriple` override).
+ *     Requires the host to have run
+ *     `rustup target add <target>` for that triple.
+ *   - `edition`: `--edition`. Defaults to `2024`.
+ *   - `crateType`: `--crate-type`. Defaults to `lib`.
+ *   - `optLevel`: `-C opt-level=…`. Defaults to `2`.
+ *   - `rustcFlags`: appended verbatim to the rustc command line.
+ *   - `onProgress`: status callback. Stages: `run-host-rustc`.
+ * @returns {Promise<string>} LLVM IR text from `--emit=llvm-ir`.
+ */
+export async function rsHostToIR(source, opts = {}) {
+    if (typeof source !== 'string') {
+        throw new TypeError('source must be a string');
+    }
+    const name = opts.name ?? 'in.rs';
+    assertSafeName(name);
+    const driver = await loadRustcHostDriver();
+    return driver(source, { ...opts, name });
+}

--- a/llvm-mov/wasm/tests/fixtures/host_ret_42.rs
+++ b/llvm-mov/wasm/tests/fixtures/host_ret_42.rs
@@ -1,0 +1,26 @@
+// Host-rustc smoke fixture for `rsHostToIR()`. Mirrors the existing
+// `examples/rust/main/src/main.rs` source (edition 2024 +
+// `#[unsafe(no_mangle)]`) so the bypass path covers the same surface
+// our cargo-built example uses.
+//
+// Native invocation (what the test runs):
+//
+//   rustc --edition=2024 --crate-type=lib --target=i686-unknown-linux-gnu \
+//         --emit=llvm-ir -C panic=abort -C overflow-checks=false \
+//         -C opt-level=2 -C debuginfo=0 -C strip=symbols host_ret_42.rs
+//
+// Requires the host toolchain to have `i686-unknown-linux-gnu` added:
+//
+//   rustup target add i686-unknown-linux-gnu
+
+#![no_std]
+
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_main() -> i32 {
+    42
+}

--- a/llvm-mov/wasm/tests/run-rust-host.sh
+++ b/llvm-mov/wasm/tests/run-rust-host.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Host-rustc bypass smoke test.
+#
+# Drives the host `rustc` (whatever's on $PATH or $RUSTC) through
+# `rsHostToIR()` and asserts the returned LLVM IR contains a
+# `define ... @rust_main(` line. This is the "works today" Rust
+# frontend — sister to `tests/run-rust.sh` (which exercises the
+# wasm-hosted rubrc artefact, currently only emits wasm32 IR).
+#
+# Prereq: `rustup target add i686-unknown-linux-gnu` on the host.
+# Without it rustc dies with "the toolchain doesn't support …".
+
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+
+if ! command -v "${RUSTC:-rustc}" >/dev/null 2>&1; then
+    echo "error: ${RUSTC:-rustc} not on PATH — set RUSTC=… to override" >&2
+    exit 2
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+pass=0
+fail=0
+fail_names=()
+
+run_rs_host_fixture() {
+    local rs="$1" name dir
+    name="$(basename "$rs" .rs)"
+    dir="$work/$name"
+    mkdir -p "$dir"
+
+    local wasm_ll="$dir/host.ll"
+    local node_log="$dir/host.log"
+    if node --input-type=module -e "
+        import { readFileSync, writeFileSync } from 'node:fs';
+        import { rsHostToIR } from '$root/llvm-mov.mjs';
+        const src = readFileSync('$rs', 'utf8');
+        const ir = await rsHostToIR(src, { name: '$name.rs' });
+        writeFileSync('$wasm_ll', ir);
+    " 2>"$node_log"; then
+        if grep -qE 'define .* @rust_main\(' "$wasm_ll"; then
+            pass=$((pass + 1))
+            echo "PASS  $name (host-rs smoke)"
+        else
+            fail=$((fail + 1))
+            fail_names+=("$name(no rust_main in IR)")
+            echo "FAIL  $name (host-rs smoke) — IR missing 'define … @rust_main('"
+            head -20 "$wasm_ll" | sed 's/^/    /'
+        fi
+    else
+        fail=$((fail + 1))
+        fail_names+=("$name(node threw)")
+        echo "FAIL  $name (host-rs smoke) — node side threw"
+        sed 's/^/    /' "$node_log" | head -20
+    fi
+}
+
+shopt -s nullglob
+for rs in "$here"/fixtures/host_*.rs; do
+    run_rs_host_fixture "$rs"
+done
+shopt -u nullglob
+
+echo
+echo "host-rust smoke: $pass passed, $fail failed"
+if [ "$fail" -ne 0 ]; then
+    echo "failing:"
+    for n in "${fail_names[@]}"; do echo "  - $n"; done
+    exit 1
+fi


### PR DESCRIPTION
## 概要

PR #34 で入れた `rsToIR()` (wasm 経由 rustc) の sister として、**ホスト側の `rustc` を subprocess で叩く** `rsHostToIR()` を追加。wasm 経由の rustc artefact が i686 sysroot を持つようになるまでの「今すぐ動く」 Rust frontend として機能する。

```
.c  ──clang.wasm──→ .ll ──llvm-mov-llc.wasm──→ .s ──as.wasm──→ .o ──ld.wasm──→ ELF32
    │                  │
    └→ cToIR()         └→ compile()

.rs ──rustc.wasm──→ .ll  ─┘   (#34 で着工、i686 artefact 待ち)
    │
    └→ rsToIR()

.rs ──host rustc──→ .ll  ─┘   ← 本 PR (Node-only)
    │
    └→ rsHostToIR()
```

## なぜ host bypass

PR #34 の `rsToIR()` は rubrc v0.2.0 artefact (Rust 1.83-dev、`wasm32-wasip1` / `x86_64-unknown-linux-gnu` のみ) でしか動かず、出力 IR の triple は `wasm32-unknown-wasi`。これは `llvm-mov-llc` (i386 ABI 前提) にそのまま流せない。自前 `rustc.wasm` ビルドは Run 4-9 の試行で LLVM-for-WASI 移植が深掘り必要と判明し PR #34 では scaffold 状態で revert 済。

一方、ホストには既に `rustup target add i686-unknown-linux-gnu` が入っているので、host rustc を `--target=i686-unknown-linux-gnu --emit=llvm-ir` で走らせれば **wasm tail (llvm-mov-llc.wasm → as.wasm → ld.wasm) がそのまま受け取れる IR** が今すぐ手に入る。explorer の Rust path を visible に立ち上げる前段としてはこれで十分。

## 設計

- **API**: `rsHostToIR(source, opts)` — `rsToIR` と同 I/O shape。Node-only (subprocess + filesystem)
- **Driver**: `lib/rustc-host-driver.mjs` で `child_process.spawn` 経由、tempdir に `.rs` を書き出し → rustc → `<stem>.ll` を読み戻す
- **Defaults**: `edition=2024` / `target=i686-unknown-linux-gnu` / `crate-type=lib` / `opt-level=2` / `panic=abort` / `overflow-checks=false` / `debuginfo=0` / `strip=symbols`
- **オーバライド**: `opts.rustc` (binary path) / `opts.rustcFlags` (生 flags 追記) など
- **型**: `RsHostToIROptions` + `rsHostToIR` を `llvm-mov.d.ts` に export、`ProgressEvent` に `run-host-rustc` ステージ追加

## テスト

- `make test-rust-host` (= `tests/run-rust-host.sh`) — `host_ret_42.rs` から `define ... @rust_main(` を含む IR が返ることをアサート
- 既存 `make test-rust` (wasm path) とは独立、`wasmtime` 不要

### 検証ログ

```
$ bash tests/run-rust-host.sh
PASS  host_ret_42 (host-rs smoke)

host-rust smoke: 1 passed, 0 failed
```

## prereq

ホスト側に:
```sh
rustup target add i686-unknown-linux-gnu
```

入っていないと rustc が "the toolchain doesn't support ..." で落ちる (driver 側で stderr をそのまま投げる)。

## 残ギャップ (この PR では出さない)

- **explorer 統合**: `src/lib/wrappers.ts` に Rust toolchain dropdown 追加 → `rsHostToIR` 呼び出し。ただしブラウザ側は subprocess 使えないので、Node 経由の build step か、`turbo86` 風の WebSocket 経由 backend service を組む必要あり
- **ブラウザ経路の Rust frontend**: 本格 in-wasm rustc (i686 sysroot 付き artefact) ができるか、上記 backend service 路線
- **`.rs → .s → .o → ELF32` の通し E2E**: `make build` (multi-hour LLVM) が前提なのでこの worktree では未実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)