### PR TITLE
linux-mov: Linux を x86mov32 へ移植する設計 (機械定義 / 特権差分 / kill-test)

### DIFF
--- a/linux-mov/DESIGN.md
+++ b/linux-mov/DESIGN.md
@@ -130,12 +130,12 @@ spec は profile 定義（pv-kernel は PV-CPU/IRQ/MMU を *含む*）、本書�
 - **R1（最大）**: コンパイラ/カーネル意味論互換性。inline asm は氷山の一角（compiler barrier・`asm goto`・exception-table fixup・object layout…）。→ L0.5 kill-test で早期に殺す。
 - **R2**: llvm-mov の inline asm 実装コスト不明。L3 を L0.5 の優先順で段階導入。
 - **R3（host 間乖離）**: PV を movie86 だけが持つと「movie86 で動くが x86-host で落ちる」。→ (a) fault を x86-like に固定（spec §6.1）、(b) PV/プラットフォームを named profile + x86-host 実行層として明示（spec §2）、(c) conformance fixture を両 host で通す CI ゲート（spec §8）。
-- **R4**: movie86 の機械化で userspace ランナーの単純さを失う。`Memory`/実行モデルの trait を壊さず、PV は opt-in feature・profile で段階導入。
+- **R4（緩和）**: movie86 の機械化で userspace ランナーの単純さを失う点は、**AS-IS 維持が制約でない**ため許容（design 決定）。movie86 を x86mov32 リファレンス機械へ自由に再形成してよい（flat メモリ→interval map、userspace runner→機械、特権状態の追加）。既存 movfuscator/wasm/explorer 互換は best-effort の optional legacy モードで設計を縛らない。残る配慮は「再形成を段階的に行い各ステージを緑に保つ」ことだけ。
 - **R5（テキストパッチ）**: Linux の alternatives/static-keys/ftrace/kprobes/paravirt-patch は自己書き換え（spec §5 で base 不許可）。→ PV-TEXTPATCH（spec §7.8）か「対象 config で全テキスト改変無効化」のいずれか。L0.5 で現実性を判定。
 
 ## 6. 即時の design TODO
 
-- [x] TODO-1: **決定（round-5）** — pv-min console は spec アドレス `0x1FF0_1000`（PV-CONSOLE）に置く。movie86 既存 `0x1FFE_0000` は `x86mov32-compat-movfuscator` 専用として保持し、新 PV 窓と共存（spec §7.1）
+- [x] TODO-1: **決定** — pv-min console は spec アドレス `0x1FF0_1000`（PV-CONSOLE）。**movie86 AS-IS は維持制約でない**ため PV-MMIO 窓は自由に設計でき、legacy `0x1FFE_0000` の共存は必須でなく best-effort（compat-movfuscator が要るときだけ供給, spec §2 design stance）
 - [ ] TODO-2: 割り込み配送モデル（poll 型 → 強制ジャンプ型）の境界確定（spec §7.6）
 - [ ] TODO-3: ページテーブル形式（x86 PTE 流用可否）を L0.5 結果で判断（spec §7.7）
 - [x] TODO-4: **決定 — 自作の極小カーネル**（L1, inline asm 非依存）

--- a/linux-mov/DESIGN.md
+++ b/linux-mov/DESIGN.md
@@ -72,7 +72,7 @@ substrate の責務（= 差分そのもの、過不足なし）:
 | 実行中 | 実 timer/IRQ を実 IDT で受け、x86mov32 trap frame（spec §6.3）合成 → PV ハンドラへ jump |
 | PV `IRET` mov | trap frame から復帰 |
 
-PV 境界は稀なので計算は全速・仲介は薄い。
+**near-native の正確な範囲（round-4）**: 通常の計算と*直接マップした*安全な MMIO は near-native。一方 not-present #PF で捕える PV 制御レジスタは **意図的に高コストな #PF+decode exit** であり、hot path に置かない（高頻度 I/O は実 MMIO ページ直マップで回避）。「near-native」は計算とマップ済み MMIO の話で、trap される PV アクセスではない。
 
 **substrate の形態**:
 1. **qemu machine type `x86mov32`**（推奨）: guest=mov カーネル、qemu が PV-MMIO デバイス + 割り込み注入を提供。movie86 と qemu がこの spec の2実装になり conformance（spec §8）に乗る。
@@ -89,9 +89,13 @@ substrate は RISC-V の **OpenSBI（M-mode ランタイム）に相当する薄
 
 substrate の仕事の大半は **純計算** — faulting `mov` のデコード（ModRM/SIB/disp/幅）、trap frame（spec §6.3）構築、ゲストメモリ/レジスタ操作、whitelist 検証、EIP 前進。**これらは全て mov 化でき、llvm-mov でコンパイルできる**。
 
-irreducible に非-mov なのは **X86-DELTA §4 の M セットそのもの** = `lgdt`/`lidt`/`mov CRn`/`sti`/`cli`/`iret`/`invlpg` + real-mode boot stub（port I/O は MMIO デバイス採用で回避可）。数十命令オーダーの固定スタブ。
+irreducible に非-mov なのは **カーネル PV M-set ⊂ substrate 集合（真の上位集合, round-4 補正）**。カーネルが PV-MMIO で要求する特権効果（`lidt`/`mov CRn`/`sti`/`iret` 等）に加え、substrate **固有**の host 義務が乗る: real-mode→protected-mode boot（A20/`lgdt`/far jump）、#PF cause 読み（`mov from CR2`）、実 IRQ コントローラ操作 + EOI、whitelist/実行権限の強制フック。数十命令オーダーの固定スタブ群。
 
-→ **substrate = mov-heavy（llvm-mov 製）+ 最小の非-mov 特権スタブ**。これは会話初期の「mov-heavy + 小さな asm shim」を、*カーネル全体ではなく substrate に正しくスコープした*もの。美しい閉包: x86mov32 がカーネルから追い出した特権は、最小化されて substrate の小さな非-mov 核として再出現する。ゼロにはできない（X86-DELTA の結論）が周辺は全部 mov にできる。
+→ **substrate = mov-heavy（llvm-mov 製ロジック）+ 最小の非-mov 特権スタブ群**。これは会話初期の「mov-heavy + 小さな asm shim」を、*カーネル全体ではなく substrate に正しくスコープした*もの。
+
+**substrate のコンパイラ要件は L0.5（guest 用）と別**（round-4）: substrate の mov ロジックから非-mov スタブを **固定 ABI で呼ぶ**手段が要る（外部 asm オブジェクト or builtin、fault-handler ABI、スタブ周りの clobber/stack/割り込みマスク制御）。これは「**guest Linux は任意 inline asm 不要 / substrate は固定の非-mov asm スタブを持ちうる**」という棲み分けで、L0.5 の結論を覆さない。
+
+美しい閉包: x86mov32 がカーネルから追い出した特権は、最小化されて substrate の非-mov 核として再出現する。ゼロにはできない（X86-DELTA の結論）が周辺は全部 mov にできる。
 
 2つの哲学:
 - **実用（qemu/KVM）**: substrate = 既存の大きな非-mov ソフト（qemu/KVM/host Linux）。簡単だが mov でない。

--- a/linux-mov/DESIGN.md
+++ b/linux-mov/DESIGN.md
@@ -1,0 +1,124 @@
+# linux-mov — Linux を x86mov32 へ移植する
+
+> 状態: **設計フェーズ（実装前）**。本書は合意形成のためのたたき台であり、コードは未着手。
+>
+> **本書は [`X86MOV32-SPEC.md`](./X86MOV32-SPEC.md)（正典の機械定義 v0.2-draft）に従属する**。機械の ISA/メモリ/fault/PV-MMIO/profile 定義は spec を正とする。本書はそれを Linux に適用するロードマップ。
+
+## 0. ゴールと非ゴール
+
+- **ゴール**: Linux を **新アーキテクチャ `arch/x86mov32/`** として移植し、ほぼ全てが `mov`(+最小制御転送) から成る ELF32 イメージとしてビルドして、movie86（x86mov32 のリファレンス実装）および x86-host 実行層（実 x86/qemu）上で起動する。
+- **非ゴール（当面）**: SMP、実デバイスドライバ群、性能。まず UP・no-device・boot-to-shell の一点突破。
+
+## 1. これは「arch/x86 + mov backend」ではなく「新アーキ移植」である
+
+x86mov32 を独立 base ISA と定義した（spec §1）以上、Linux 側も **arch/x86 の流用ではなく `arch/x86mov32/` の新規追加**として進める。
+
+**主 template は `arch/riscv`（32bit）**。x86mov32 は MMIO-only I/O・device tree・単一 trap ベクタという点で構造的に RISC 的（spec §1）なので、参照すべきは arch/x86 ではなく arch/riscv。具体的対応：trap 処理 ↔ riscv trap（sepc/scause/stval/sret, spec §6.3）、PV-CPU ↔ trap CSR + SBI、PV-TIMER ↔ CLINT、PV-IRQ ↔ CLINT/PLIC、ハードウェア記述 ↔ **device tree**（spec §7.10）。既知の良設計をほぼ移植できる。
+
+**なぜ arch/x86 を流用しないか**: arch/x86 の最難関（segmentation・protected-mode entry・alternatives/static-keys パッチ・paravirt-ops・GDT/IDT 直叩き・ポート I/O・ACPI 列挙）は、まさに mov 化が難しい部分であり、spec §1(b) で「x86 専用拡張」として x86mov32 が継承しないと決めた領域そのもの。新アーキなら **それらを最初から持たず**、自分が制御できる最小面（ABI・ページテーブル形式・trap frame・entry/exit・atomics・barrier）だけを、x86 と共有する MMIO 機構（spec §1b）の上に定義できる。
+
+**ペリフェラル**: デバイス *設計* は x86 の馴染んだもの（16550 UART 等）を参考にしてよいが、*記述・発見* は device tree に統一（spec §7.10）。movie86 / x86-host 層が起動時に DTB を渡し（spec §9 kernel boot）、カーネルは DT から discover する。
+
+**エンコーディングは維持**: arch は新規だが機械語は i386 サブセット（spec §1）。ゆえに movie86 と実 x86 の両 host で走る性質は byte レベルで保たれる。
+
+### 旧 (A)/(B) 二系統の整理
+
+0.1-draft の「(A) arch/x86+shim / (B) para-virt movie86」という対立は解消した。新しい整理は **「単一の新アーキ x86mov32 を、複数の host で走らせる」**：
+
+| host | 位置づけ |
+|---|---|
+| **movie86** | x86mov32（base + PV）のリファレンス実装。主開発ターゲット |
+| **x86-host 実行層**（実 x86/qemu） | base 計算コアは native 実行、PV システム拡張とプラットフォーム契約を薄い非-mov 層で供給（spec §1(b)(c)） |
+
+## 2. 既存資産（実地確認済み）
+
+- **movie86**: ELF32 i386 静的リンク実行、flat メモリ、`0x1FFE_0000` ページへの mov を AbiHost に routing するマジックアドレス機構（= PV-MMIO の母体）。`Memory` は trait。特権状態・割り込み・MMU・デバイスは未実装（= 実装対象）。
+- **llvm-mov**: 整数・制御フロー（全 Jcc を mov 化）・call/ret・f32/f64 soft-float を mov-only 化済み。Rust/C→ELF パイプライン。**inline asm / atomics / varargs / native i64 が無い**。実証規模 ~200 LoC。spec §1(a) の「計算拡張→base 還元」を担うのがこれ。
+
+## 3. ロードマップ（ステージ制 — TDD、各ステージは spec の profile を宣言）
+
+> **順序原則（smart-friend レビュー反映）**: 最大リスクは PV-MMIO ではなく **コンパイラ/カーネルの意味論互換性**。よって割り込み機構（L2）に労力を注ぐ前に **L0.5 = feasibility kill-test** を割り込ませ、その結果で PV-CPU/MMU/IRQ の意味論（spec §7.5–§7.7）と llvm-mov の作業順序を決める。
+
+| Stage | profile | 内容 | 緑の判定 |
+|---|---|---|---|
+| **L0** | pv-min | movie86 に PV-MMIO ウィンドウ + PV-CONSOLE(`PUTC`)。spec §6.1 の x86-like 同期 fault（未マップ=fault）も実装 | 別 PV ページへの mov が console handler に届く単体 + base/pv-min conformance fixture（spec §8） |
+| **L0.5** | — | **Linux/x86mov32 feasibility kill-test**（コード変更なし）。実 Linux ソースに対し inline asm 形態・**`asm goto`・`"memory"` clobber・exception-table/fault fixup**・atomics・builtins・special sections・linker script・varargs/i64 を棚卸し。**kill 条件**: llvm-mov がコンパイラバリア + faultable asm/制御フロー fixup をモデル化できないと判明したら、ロードマップを再設計（atomics より先に詰む論点） | blocking list が spec 0.3 入力として確定 |
+| **L1** | pv-min | 自作極小カーネル（数百行 C, **inline asm 不使用**）を llvm-mov でビルドし `PUTC` に mov して `"Hello, x86mov32\n"` を出して停止 | E2E: ELF を movie86 で実行→期待出力。objdump で `.text` が mov(+jmp) のみ |
+| **L2** | pv-kernel | PV-CPU(`INTR_MASK`/`IDT_BASE`/`IRET`) + spec §6.3 trap frame + poll 型 PV-IRQ。協調スケジューラの土台 | trap frame 往復 / マスク制御 / tick 単体 + E2E + pv-kernel conformance（一部） |
+| **L3** | — | llvm-mov に **inline asm → mov**（mainline への分水嶺）。L0.5 の blocking list 順で、まず単純制約→`"memory"`/volatile→`asm goto` | 新規 inline-asm fixture が mov-only で通る |
+| **L4** | — | atomics（UP 前提で `lock` 省略 + cmpxchg を mov 列に） | atomic fixture |
+| **L5** | pv-kernel | PV-MMU(`PGDIR`/`FLUSH`/`FAULT_ADDR`) + `PagedMemory`。demand paging / page fault 配送（spec §6.2/§7.7） | page fault → FAULT_ADDR / PGDIR で VA→PA |
+| **L6** | pv-kernel | 強制ジャンプ型割り込み（preemption） | タイマで別タスクへ切替 |
+| **L7+** | pv-kernel | `arch/x86mov32/` を実 Linux に追加し、最小 config で boot→`start_kernel`→early console へ。テキストパッチ方針（spec §7.8）を確定 | early console が PV-CONSOLE に出る |
+| **L8** | pv-kernel | x86-host substrate（qemu machine type `x86mov32`）で実 x86 経路を実証（§3.5）。同じイメージが movie86 と qemu の両方で起動 | conformance fixture（spec §8）が両 host で緑 |
+
+> L0–L1 が「mov だけで動く極小カーネルが 1 文字出す」= 最初の旗。L0.5 が生死を分け、L3 が mainline への分水嶺。L8 が「x86 でも起動」の実証。
+
+## 3.5 x86-host 実行層と「x86 で起動できるか」
+
+**結論（設計上）: 起動可能。素の x86 ではなく、x86-host substrate（実 x86 ring0、非-mov）の上で、計算は near-native・PV 境界のみ仲介して動く。** ただし未検証の設計主張であり、L8 の実証は下記 conformance gate を満たすことが条件（round-3 反映）。詳細根拠は [`X86-DELTA.md`](./X86-DELTA.md)。
+
+- カーネルの計算コード（mov バイト列）は実 x86 CPU が native 実行（i386 サブセット, spec §1a）。エミュレーションではなく全速。
+- 足りないのは X86-DELTA §5 の差分（boot・PV-MMU・保護・割り込み配送・textpatch）だけ。これを substrate が供給する。**新アーキ化で「x86 で走る」性質は失っていない**（encoding を x86 サブセットに保った見返り）。
+
+substrate の責務（= 差分そのもの、過不足なし）:
+
+| カーネル | substrate（実 x86） |
+|---|---|
+| (boot 前) | real→protected mode・初期ページング・DTB を渡して jump |
+| PV-MMU `PGDIR` mov | 実 CR3/PT 設定 → 以後 HW MMU が保護・変換を native 強制（全速） |
+| PV-CONSOLE/TIMER mov | UART/timer デバイス応答（普通の MMIO emulation） |
+| 実行中 | 実 timer/IRQ を実 IDT で受け、x86mov32 trap frame（spec §6.3）合成 → PV ハンドラへ jump |
+| PV `IRET` mov | trap frame から復帰 |
+
+PV 境界は稀なので計算は全速・仲介は薄い。
+
+**substrate の形態**:
+1. **qemu machine type `x86mov32`**（推奨）: guest=mov カーネル、qemu が PV-MMIO デバイス + 割り込み注入を提供。movie86 と qemu がこの spec の2実装になり conformance（spec §8）に乗る。
+2. **bare-metal monitor**: 実機 ring0 最小 firmware。純度最高だが手間。
+
+**既存資産**: turbo86（ptrace で mov バイナリを実 x86 に native 実行 + trap）は **userspace 版 x86-host 実行層**が既にある証拠。base/pv-min プログラム（L1 等）は turbo86 系で実 x86 に流せる。pv-kernel Linux はその system 版（qemu machine / KVM）が要る。
+
+### substrate の必須要件（conformance gate, round-3）
+
+「薄い」は計算が native という意味で、substrate 自体には正確さが要る：
+
+1. **命令 whitelist の強制**（最重要）: x86 に "mov-only モード" は無い。guest が ring0 native 実行する以上、紛れ込んだ非-mov 命令は実 x86 意味論で動いてしまう。→ **boot 前の静的検証**（イメージ全体が許可命令のみか）か **検証済みページにのみ実行権限**を与える方式が必要。コンパイラを信頼するだけでは機械 conformance にならない。
+2. **正確な i386 `mov` デコーダ**: PV-MMIO を not-present #PF + 命令デコードで捕える方式は、ModRM/SIB/disp/幅/方向/実効アドレスを正しく解く mov デコーダを要する（full x86 decode は不要だが正確さ必須）。
+3. **EIP 前進 vs 再実行の規則**: MMIO エミュレーションは faulting 命令を再実行せず、結果を合成して **EIP を mov の次へ前進**。真の page fault は **EIP を faulting 命令に残す**。この区別を substrate spec に明記。
+4. **host 例外の完全隠蔽**: EFLAGS 無し trap frame（spec §6.3）が成立するのは、許可 guest 命令が flags を観測しないから。host の timer IRQ・#PF・#UD は x86mov32 trap frame に翻訳するか substrate バグ扱い。`popf`/`pushf`/`lahf`/`cmovcc`/string ops 等は **whitelist で排除されている**ことが前提。
+5. **PV アクセスは高コスト exit**: #PF+decode は稀な制御（MMU 設定・console char・timer・`PGDIR`・`IRET`）には十分だが **高頻度 I/O には不可**。高頻度経路は実 MMIO ページを直接マップする等の最適化が要る。near-native なのは計算であって PV 境界ではない。
+6. **分離**: bare-metal monitor 形態は、guest と substrate が同 ring だと guest が substrate のページテーブル/IDT/GDT/実行マップを壊せて崩壊する。実質 **micro-hypervisor**（qemu/KVM 境界の方がクリーン）。
+7. **SMC**: native 実行が妥当なのは W^X + テキストパッチ無効化の config か、PV-TEXTPATCH の host 承認プロトコル経由のときだけ（spec §5/§7.8）。
+
+> L0/L1 を movie86 で固めた後、上記 gate を満たす qemu machine type で L8 として実機経路を実証する。
+
+## 4. PV scope（spec §2 との整合 — 0.1 の矛盾を解消）
+
+spec は profile 定義（pv-kernel は PV-CPU/IRQ/MMU を *含む*）、本書はその **実装の段階**を定める。両者は別物：
+
+- **実装が先行するのは pv-min（console+timer）まで**（L0–L1）。
+- **pv-kernel（PV-CPU/IRQ/MMU・trap 配送）は spec で named + reserved 済み、実装は L2/L5/L6 で順次**。
+- 「console+timer のみ」は *いま実装する PV* の話であって、profile 定義の縮小ではない（0.1-draft の文言ミスを訂正）。
+
+## 5. リスクと未決事項
+
+- **R1（最大）**: コンパイラ/カーネル意味論互換性。inline asm は氷山の一角（compiler barrier・`asm goto`・exception-table fixup・object layout…）。→ L0.5 kill-test で早期に殺す。
+- **R2**: llvm-mov の inline asm 実装コスト不明。L3 を L0.5 の優先順で段階導入。
+- **R3（host 間乖離）**: PV を movie86 だけが持つと「movie86 で動くが x86-host で落ちる」。→ (a) fault を x86-like に固定（spec §6.1）、(b) PV/プラットフォームを named profile + x86-host 実行層として明示（spec §2）、(c) conformance fixture を両 host で通す CI ゲート（spec §8）。
+- **R4**: movie86 の機械化で userspace ランナーの単純さを失う。`Memory`/実行モデルの trait を壊さず、PV は opt-in feature・profile で段階導入。
+- **R5（テキストパッチ）**: Linux の alternatives/static-keys/ftrace/kprobes/paravirt-patch は自己書き換え（spec §5 で base 不許可）。→ PV-TEXTPATCH（spec §7.8）か「対象 config で全テキスト改変無効化」のいずれか。L0.5 で現実性を判定。
+
+## 6. 即時の design TODO
+
+- [ ] TODO-1: PV-MMIO アドレスマップを movie86 既存マップ（`0x1FFE_0000`）と突き合わせ確定（spec §7.1）
+- [ ] TODO-2: 割り込み配送モデル（poll 型 → 強制ジャンプ型）の境界確定（spec §7.6）
+- [ ] TODO-3: ページテーブル形式（x86 PTE 流用可否）を L0.5 結果で判断（spec §7.7）
+- [x] TODO-4: **決定 — 自作の極小カーネル**（L1, inline asm 非依存）
+- [x] TODO-5: **決定 — 実装は最小 PV(console+timer)先行**、pv-kernel は spec 予約・段階実装（§4）
+- [x] TODO-6: **決定 — 新アーキ `arch/x86mov32/` として移植**（arch/x86 流用せず, §1）
+- [x] TODO-7: **決定 — ターゲット名 `x86mov32`**
+- [x] TODO-8: **決定 — 主 template は arch/riscv(rv32)**。trap/CLINT/PLIC/SBI/DT を移植参考に（§1, spec §6.3/§7.4–§7.6/§7.10）
+- [x] TODO-9: **決定 — ハードウェア記述は device tree**。boot で DTB を渡す（spec §7.10/§9）
+- [ ] TODO-10: L0.5 kill-test の具体的チェックリストと判定基準を起こす（arch/riscv の inline asm/atomics/fixup の使い方も比較参照点に）（spec §10 → 0.3）
+- [ ] TODO-11: PV-* の DT binding（compatible 文字列・reg・interrupts）を起こす（spec §7.10）

--- a/linux-mov/DESIGN.md
+++ b/linux-mov/DESIGN.md
@@ -135,7 +135,7 @@ spec は profile 定義（pv-kernel は PV-CPU/IRQ/MMU を *含む*）、本書�
 
 ## 6. 即時の design TODO
 
-- [ ] TODO-1: PV-MMIO アドレスマップを movie86 既存マップ（`0x1FFE_0000`）と突き合わせ確定（spec §7.1）
+- [x] TODO-1: **決定（round-5）** — pv-min console は spec アドレス `0x1FF0_1000`（PV-CONSOLE）に置く。movie86 既存 `0x1FFE_0000` は `x86mov32-compat-movfuscator` 専用として保持し、新 PV 窓と共存（spec §7.1）
 - [ ] TODO-2: 割り込み配送モデル（poll 型 → 強制ジャンプ型）の境界確定（spec §7.6）
 - [ ] TODO-3: ページテーブル形式（x86 PTE 流用可否）を L0.5 結果で判断（spec §7.7）
 - [x] TODO-4: **決定 — 自作の極小カーネル**（L1, inline asm 非依存）

--- a/linux-mov/DESIGN.md
+++ b/linux-mov/DESIGN.md
@@ -1,149 +1,89 @@
-# linux-mov — Linux を x86mov32 へ移植する
+# Linux を x86mov32 へ移植する — 設計
 
-> 状態: **設計フェーズ（実装前）**。本書は合意形成のためのたたき台であり、コードは未着手。
->
-> **本書は [`X86MOV32-SPEC.md`](./X86MOV32-SPEC.md)（正典の機械定義 v0.2-draft）に従属する**。機械の ISA/メモリ/fault/PV-MMIO/profile 定義は spec を正とする。本書はそれを Linux に適用するロードマップ。
+> 設計フェーズ（実装前）。機械の定義は [`X86MOV32-SPEC.md`](./X86MOV32-SPEC.md) を正とし、本書はそれを Linux に適用するロードマップ。
 
-## 0. ゴールと非ゴール
+## ゴール
 
-- **ゴール**: Linux を **新アーキテクチャ `arch/x86mov32/`** として移植し、ほぼ全てが `mov`(+最小制御転送) から成る ELF32 イメージとしてビルドして、movie86（x86mov32 のリファレンス実装）および x86-host 実行層（実 x86/qemu）上で起動する。
-- **非ゴール（当面）**: SMP、実デバイスドライバ群、性能。まず UP・no-device・boot-to-shell の一点突破。
+Linux を **新アーキ `arch/x86mov32`** として移植し、ほぼ全てが `mov`(+最小制御転送) から成る ELF32 イメージとしてビルドして、movie86（リファレンス実装）と実 x86/qemu（substrate 上）で起動する。当面は UP・no-device・boot-to-shell に絞る（SMP・実ドライバ・性能は非ゴール）。
 
-## 1. これは「arch/x86 + mov backend」ではなく「新アーキ移植」である
+## なぜ新アーキ（arch/x86, mov backend ではなく）
 
-x86mov32 を独立 base ISA と定義した（spec §1）以上、Linux 側も **arch/x86 の流用ではなく `arch/x86mov32/` の新規追加**として進める。
+x86mov32 を独立 base ISA と定義した以上（spec §1）、Linux 側も **`arch/riscv`(rv32) を主 template に `arch/x86mov32` を新設**する。x86mov32 は MMIO-only I/O・device tree・単一 trap ベクタという点で構造的に RISC 的で、arch/x86 の最難関（segmentation・protected-mode entry・alternatives/paravirt・ポート I/O・ACPI）— まさに mov 化が難しく、x86mov32 が継承しないと決めた領域 — を最初から持たずに済む。
 
-**主 template は `arch/riscv`（32bit）**。x86mov32 は MMIO-only I/O・device tree・単一 trap ベクタという点で構造的に RISC 的（spec §1）なので、参照すべきは arch/x86 ではなく arch/riscv。具体的対応：trap 処理 ↔ riscv trap（sepc/scause/stval/sret, spec §6.3）、PV-CPU ↔ trap CSR + SBI、PV-TIMER ↔ CLINT、PV-IRQ ↔ CLINT/PLIC、ハードウェア記述 ↔ **device tree**（spec §7.10）。既知の良設計をほぼ移植できる。
+既知の良設計をほぼ移植できる：trap 処理↔riscv trap（sepc/scause/stval/sret）、PV-CPU↔trap CSR + SBI、PV-TIMER↔CLINT、PV-IRQ↔CLINT/PLIC、ハードウェア記述↔device tree。ペリフェラルは設計を x86 の馴染んだもの（16550 UART 等）から借りてよいが、記述・発見は DT に統一する。
 
-**なぜ arch/x86 を流用しないか**: arch/x86 の最難関（segmentation・protected-mode entry・alternatives/static-keys パッチ・paravirt-ops・GDT/IDT 直叩き・ポート I/O・ACPI 列挙）は、まさに mov 化が難しい部分であり、spec §1(b) で「x86 専用拡張」として x86mov32 が継承しないと決めた領域そのもの。新アーキなら **それらを最初から持たず**、自分が制御できる最小面（ABI・ページテーブル形式・trap frame・entry/exit・atomics・barrier）だけを、x86 と共有する MMIO 機構（spec §1b）の上に定義できる。
+## 既存資産
 
-**ペリフェラル**: デバイス *設計* は x86 の馴染んだもの（16550 UART 等）を参考にしてよいが、*記述・発見* は device tree に統一（spec §7.10）。movie86 / x86-host 層が起動時に DTB を渡し（spec §9 kernel boot）、カーネルは DT から discover する。
+- **movie86**: ELF32 i386 ランナー。`mov` を特定アドレスへ送ると host へ routing するマジックアドレス機構を持つ（PV-MMIO の母体）。`Memory` は trait。特権状態・割り込み・MMU・デバイスは未実装（= 実装対象）。
+- **llvm-mov**: 整数・制御フロー（全 Jcc を mov 化）・call/ret・f32/f64 soft-float を mov 化済み。Rust/C→ELF。inline asm / atomics / varargs / native i64 は未対応。spec §1(a) の「計算拡張→base 還元」を担う。
 
-**エンコーディングは維持**: arch は新規だが機械語は i386 サブセット（spec §1）。ゆえに movie86 と実 x86 の両 host で走る性質は byte レベルで保たれる。
+## ロードマップ
 
-### 旧 (A)/(B) 二系統の整理
-
-0.1-draft の「(A) arch/x86+shim / (B) para-virt movie86」という対立は解消した。新しい整理は **「単一の新アーキ x86mov32 を、複数の host で走らせる」**：
-
-| host | 位置づけ |
-|---|---|
-| **movie86** | x86mov32（base + PV）のリファレンス実装。主開発ターゲット |
-| **x86-host 実行層**（実 x86/qemu） | base 計算コアは native 実行、PV システム拡張とプラットフォーム契約を薄い非-mov 層で供給（spec §1(b)(c)） |
-
-## 2. 既存資産（実地確認済み）
-
-- **movie86**: ELF32 i386 静的リンク実行、flat メモリ、`0x1FFE_0000` ページへの mov を AbiHost に routing するマジックアドレス機構（= PV-MMIO の母体）。`Memory` は trait。特権状態・割り込み・MMU・デバイスは未実装（= 実装対象）。
-- **llvm-mov**: 整数・制御フロー（全 Jcc を mov 化）・call/ret・f32/f64 soft-float を mov-only 化済み。Rust/C→ELF パイプライン。**inline asm / atomics / varargs / native i64 が無い**。実証規模 ~200 LoC。spec §1(a) の「計算拡張→base 還元」を担うのがこれ。
-
-## 3. ロードマップ（ステージ制 — TDD、各ステージは spec の profile を宣言）
-
-> **順序原則（smart-friend レビュー反映）**: 最大リスクは PV-MMIO ではなく **コンパイラ/カーネルの意味論互換性**。よって割り込み機構（L2）に労力を注ぐ前に **L0.5 = feasibility kill-test** を割り込ませ、その結果で PV-CPU/MMU/IRQ の意味論（spec §7.5–§7.7）と llvm-mov の作業順序を決める。
+各ステージは TDD（失敗するテスト→実装→緑）。各ステージは spec の profile を宣言する。
 
 | Stage | profile | 内容 | 緑の判定 |
 |---|---|---|---|
-| **L0** | pv-min | movie86 に PV-MMIO ウィンドウ + PV-CONSOLE(`PUTC`)。spec §6.1 の x86-like 同期 fault（未マップ=fault）も実装 | 別 PV ページへの mov が console handler に届く単体 + base/pv-min conformance fixture（spec §8） |
-| **L0.5** ✅ | — | **Linux/x86mov32 feasibility kill-test** → 結果 [`L0.5-KILLTEST.md`](./L0.5-KILLTEST.md)。**判定 SURVIVES**（二者独立検証）。config レベル BLOCKER なし（UP/nommu/no-SMC/no-jumplabel で難所は全て無効化 or 純 C 化）。残るは llvm-mov の限定作業（volatile codegen・空+operand バリア・i386 varargs・i64 helper lower・C irq-flag）。任意 inline asm は first boot 不要 | 完了 |
-| **L1** | pv-min | 自作極小カーネル（数百行 C, **inline asm 不使用**）を llvm-mov でビルドし `PUTC` に mov して `"Hello, x86mov32\n"` を出して停止 | E2E: ELF を movie86 で実行→期待出力。objdump で `.text` が mov(+jmp) のみ |
-| **L2** | pv-kernel | PV-CPU(`INTR_MASK`/`IDT_BASE`/`IRET`) + spec §6.3 trap frame + poll 型 PV-IRQ。協調スケジューラの土台 | trap frame 往復 / マスク制御 / tick 単体 + E2E + pv-kernel conformance（一部） |
-| **L3a** | — | **first boot 必須のコンパイラ作業**（L0.5 確定）: volatile load/store の codegen 正しさ、空+operand 付き memory バリア、i386 SysV varargs、i64 helper-call lower（除算は do_div 経由で libgcc 除算を emit しない）、memcpy/memset emit、C `arch_local_irq_save/restore` | 各 fixture が mov-only で通る |
-| **L3b** | — | **任意制約 inline asm → mov**（広い config / driver 用、first boot 不要に後退）。段階導入、対応不能形を列挙 | inline-asm fixture |
-| **L4** | — | atomics（UP 前提で `lock` 省略 + cmpxchg を mov 列に） | atomic fixture |
-| **L5** | pv-kernel | PV-MMU(`PGDIR`/`FLUSH`/`FAULT_ADDR`) + `PagedMemory`。demand paging / page fault 配送（spec §6.2/§7.7） | page fault → FAULT_ADDR / PGDIR で VA→PA |
-| **L6** | pv-kernel | 強制ジャンプ型割り込み（preemption） | タイマで別タスクへ切替 |
-| **L7+** | pv-kernel | `arch/x86mov32/` を実 Linux に追加し、最小 config で boot→`start_kernel`→early console へ。テキストパッチ方針（spec §7.8）を確定 | early console が PV-CONSOLE に出る |
-| **L8** | pv-kernel | x86-host substrate（qemu machine type `x86mov32`）で実 x86 経路を実証（§3.5）。同じイメージが movie86 と qemu の両方で起動 | conformance fixture（spec §8）が両 host で緑 |
+| **L0** | pv-min | movie86 に PV-MMIO 窓 + PV-CONSOLE。x86-like fault（interval map）| L0 fixture（spec §8）|
+| **L0.5** ✅ | — | feasibility kill-test（[`L0.5-KILLTEST.md`](./L0.5-KILLTEST.md)、判定 SURVIVES）| 完了 |
+| **L1** | pv-min | 自作極小カーネル（inline asm 不使用）が mov だけで `"Hello, x86mov32\n"` | E2E 出力 + `.text` が mov(+jmp) のみ |
+| **L2** | pv-kernel | PV-CPU（IDT_BASE/INTR_MASK/IRET/TRAP_STACK）+ trap frame + poll 型 PV-IRQ | trap frame 往復 / マスク / tick |
+| **L3a** | — | llvm-mov: volatile codegen・空+operand バリア・i386 varargs・i64 helper lower・memcpy/memset | 各 fixture が mov-only で通る |
+| **L3b** | — | llvm-mov: 任意制約 inline asm（広い config / driver 用）| inline-asm fixture |
+| **L4** | — | atomics（UP, 割り込みマスク）| atomic fixture |
+| **L5** | pv-kernel | PV-MMU + demand paging / page fault 配送 | page fault→FAULT_ADDR / PGDIR で VA→PA |
+| **L6** | pv-kernel | 強制ジャンプ型割り込み（preemption）| タイマで別タスクへ切替 |
+| **L7** | pv-kernel | `arch/x86mov32` を実 Linux に追加し boot→`start_kernel`→early console | early console が PV-CONSOLE に出る |
+| **L8** | pv-kernel | substrate（qemu machine type）で実 x86 起動を実証 | 同じイメージが movie86 と qemu 両方で起動 |
 
-> L0–L1 が「mov だけで動く極小カーネルが 1 文字出す」= 最初の旗。L0.5 が生死を分け、L3 が mainline への分水嶺。L8 が「x86 でも起動」の実証。
+最初の旗 = L0–L1（mov だけで 1 文字）。生死を分けたのが L0.5。mainline への分水嶺が L3a。x86 起動の実証が L8。
 
-## 3.5 x86-host 実行層と「x86 で起動できるか」
+**PV の実装段階。** spec は profile 定義（pv-kernel は PV-CPU/IRQ/MMU を含む）、本書は実装順。先に実装するのは pv-min（console+timer）まで（L0–L1）。pv-kernel は spec で予約済み、L2/L5/L6 で順次実装する。
 
-**結論（設計上）: 起動可能。素の x86 ではなく、x86-host substrate（実 x86 ring0、非-mov）の上で、計算は near-native・PV 境界のみ仲介して動く。** ただし未検証の設計主張であり、L8 の実証は下記 conformance gate を満たすことが条件（round-3 反映）。詳細根拠は [`X86-DELTA.md`](./X86-DELTA.md)。
+## x86 で起動できるか — substrate
 
-- カーネルの計算コード（mov バイト列）は実 x86 CPU が native 実行（i386 サブセット, spec §1a）。エミュレーションではなく全速。
-- 足りないのは X86-DELTA §5 の差分（boot・PV-MMU・保護・割り込み配送・textpatch）だけ。これを substrate が供給する。**新アーキ化で「x86 で走る」性質は失っていない**（encoding を x86 サブセットに保った見返り）。
+**起動できる**（設計上）。素の x86 ではなく、薄い x86-host **substrate**（実 x86 ring0、非-mov）の上で、計算は native・PV 境界だけ仲介して動く。実証は L8、下記 gate が条件。
 
-substrate の責務（= 差分そのもの、過不足なし）:
+substrate は RISC-V の **OpenSBI（M-mode ランタイム）に相当する薄い特権ファームウェア**。カーネルが PV-MMIO へ `mov` したのを substrate が処理する。movie86 はこの役割を Rust で兼ねる（だから別 substrate 不要）。movie86 が命令を解釈するのに対し、substrate は CPU に mov を native 実行させ、稀な PV 境界だけ仲介する。
 
 | カーネル | substrate（実 x86） |
 |---|---|
 | (boot 前) | real→protected mode・初期ページング・DTB を渡して jump |
-| PV-MMU `PGDIR` mov | 実 CR3/PT 設定 → 以後 HW MMU が保護・変換を native 強制（全速） |
-| PV-CONSOLE/TIMER mov | UART/timer デバイス応答（普通の MMIO emulation） |
-| 実行中 | 実 timer/IRQ を実 IDT で受け、x86mov32 trap frame（spec §6.3）合成 → PV ハンドラへ jump |
-| PV `IRET` mov | trap frame から復帰 |
+| PV-MMU `PGDIR` mov | 実 CR3/PT 設定 → 以後 HW MMU が native に保護・変換（全速）|
+| PV-CONSOLE/TIMER mov | UART/timer デバイス応答 |
+| 実行中 | 実 IRQ を実 IDT で受け、trap frame（spec §6.3）合成 → PV ハンドラへ jump |
 
-**near-native の正確な範囲（round-4）**: 通常の計算と*直接マップした*安全な MMIO は near-native。一方 not-present #PF で捕える PV 制御レジスタは **意図的に高コストな #PF+decode exit** であり、hot path に置かない（高頻度 I/O は実 MMIO ページ直マップで回避）。「near-native」は計算とマップ済み MMIO の話で、trap される PV アクセスではない。
+**substrate 自体も mov 化できる。** 仕事の大半は純計算（faulting mov のデコード・trap frame 構築・whitelist 検証・EIP 前進）で llvm-mov でコンパイルできる。irreducible に非-mov なのは X86-DELTA の M セット（`lidt`/`mov CRn`/`sti`/`iret` 等）＋ substrate 固有の host 義務（real-mode boot・`mov from CR2`・実 IRQ コントローラ+EOI・whitelist 強制）。つまり substrate = mov-heavy + 最小の非-mov 特権スタブ群（[`X86-DELTA.md`](./X86-DELTA.md) §5）。
 
-**substrate の形態**:
-1. **qemu machine type `x86mov32`**（推奨）: guest=mov カーネル、qemu が PV-MMIO デバイス + 割り込み注入を提供。movie86 と qemu がこの spec の2実装になり conformance（spec §8）に乗る。
-2. **bare-metal monitor**: 実機 ring0 最小 firmware。純度最高だが手間。
+**形態。** (1) **qemu machine type `x86mov32`**（推奨）: qemu が PV-MMIO デバイスと割り込み注入を提供。movie86 と qemu が spec の2実装になる。(2) **bare-metal monitor**: 実機 ring0 最小 firmware。
 
-### substrate の正体 = OpenSBI 相当の薄い特権ファームウェア
+**near-native の範囲。** 通常の計算と直接マップした MMIO は native 速度。not-present #PF で捕える PV 制御レジスタは意図的に高コストな exit で、hot path に置かない（高頻度 I/O は実 MMIO ページ直マップ）。
 
-substrate は RISC-V の **OpenSBI（M-mode ランタイム）に相当する薄い ring0 特権レイヤ**。カーネルが特権サービスを S-mode→M-mode `ecall` で頼むのと同様に、x86mov32 ではカーネルが PV-MMIO へ `mov` したのを substrate が処理する。非-mov の特権命令（`lidt`/`mov CR3`/`sti`/`iret`/boot）はここに **隔離**され、カーネルは 100% mov のまま native 実行される。
+**substrate の conformance gate**（L8 の条件）:
+1. **命令 whitelist の強制** — x86 に mov-only モードは無い。boot 前静的検証 or 検証済ページのみ実行可。
+2. 正確な i386 `mov` デコーダ（PV を #PF+デコードで捕える場合）。
+3. EIP 前進 vs 再実行の規則（MMIO emulation は前進、page fault は据え置き）。
+4. host 例外を x86mov32 trap frame に翻訳（`popf`/`pushf`/`cmovcc` 等は whitelist で排除済み前提）。
+5. **分離** — guest と substrate が同 ring だと崩壊。実質 micro-hypervisor（qemu/KVM がクリーン）。
 
-- **movie86 はこの役割をソフト（Rust）で兼ねる**ので別途 substrate 不要（movie86 = 機械）。substrate が要るのは実 x86 host のときだけ。
-- 決定的差: **movie86 は命令を*解釈*（インタプリタ）／ substrate は CPU に mov を*native 実行*させ稀な PV 境界だけ仲介**（薄い）。計算は全速。
+**既存資産。** turbo86（ptrace で mov バイナリを実 x86 に native 実行+trap）は userspace 版 substrate の実在証拠。base/pv-min プログラムは turbo86 系で実 x86 に流せる。
 
-### substrate 自体の mov 化
+## リスク
 
-substrate の仕事の大半は **純計算** — faulting `mov` のデコード（ModRM/SIB/disp/幅）、trap frame（spec §6.3）構築、ゲストメモリ/レジスタ操作、whitelist 検証、EIP 前進。**これらは全て mov 化でき、llvm-mov でコンパイルできる**。
+- **R1（最大）**: コンパイラ/カーネル意味論互換性。inline asm は氷山の一角。→ L0.5 で計測済み、最小 config では限定的（後述）。
+- **R2**: llvm-mov の inline asm 実装コスト。→ L3a（first-boot 必須の最小形）と L3b（任意制約）に分割。
+- **R3（host 間乖離）**: PV を movie86 だけが持つと実 x86 で落ちる。→ fault を x86-like に固定（spec §6.1）、PV を profile で明示、conformance を両 host で通す CI（spec §8）。
+- **R5（テキストパッチ）**: alternatives/static-key/ftrace は自己書き換え。→ PV-TEXTPATCH か config 無効化。
 
-irreducible に非-mov なのは **カーネル PV M-set ⊂ substrate 集合（真の上位集合, round-4 補正）**。カーネルが PV-MMIO で要求する特権効果（`lidt`/`mov CRn`/`sti`/`iret` 等）に加え、substrate **固有**の host 義務が乗る: real-mode→protected-mode boot（A20/`lgdt`/far jump）、#PF cause 読み（`mov from CR2`）、実 IRQ コントローラ操作 + EOI、whitelist/実行権限の強制フック。数十命令オーダーの固定スタブ群。
+## 決定事項
 
-→ **substrate = mov-heavy（llvm-mov 製ロジック）+ 最小の非-mov 特権スタブ群**。これは会話初期の「mov-heavy + 小さな asm shim」を、*カーネル全体ではなく substrate に正しくスコープした*もの。
+- ターゲット名 `x86mov32`、新アーキ `arch/x86mov32`（arch/x86 流用せず）、主 template は arch/riscv(rv32)。
+- ハードウェア記述は device tree、kernel boot で DTB を渡す。
+- PV-MMIO console は `0x1FF0_1000`。**movfuscator/AS-IS 互換は非ゴール**で PV 窓は自由設計、既存物の破壊を許容（spec §1 末尾）。
+- L1 のカーネルは inline asm 非依存の自作。実装は pv-min 先行。
 
-**substrate のコンパイラ要件は L0.5（guest 用）と別**（round-4）: substrate の mov ロジックから非-mov スタブを **固定 ABI で呼ぶ**手段が要る（外部 asm オブジェクト or builtin、fault-handler ABI、スタブ周りの clobber/stack/割り込みマスク制御）。これは「**guest Linux は任意 inline asm 不要 / substrate は固定の非-mov asm スタブを持ちうる**」という棲み分けで、L0.5 の結論を覆さない。
+## 未決（実装で詰める）
 
-美しい閉包: x86mov32 がカーネルから追い出した特権は、最小化されて substrate の非-mov 核として再出現する。ゼロにはできない（X86-DELTA の結論）が周辺は全部 mov にできる。
-
-2つの哲学:
-- **実用（qemu/KVM）**: substrate = 既存の大きな非-mov ソフト（qemu/KVM/host Linux）。簡単だが mov でない。
-- **純粋（bare-metal mov-heavy monitor）**: llvm-mov 製 monitor + 最小非-mov スタブ。最大限 mov・プロジェクトの美学に一致。← 「substrate も mov 化」の到達目標。
-
-**既存資産**: turbo86（ptrace で mov バイナリを実 x86 に native 実行 + trap）は **userspace 版 x86-host 実行層**が既にある証拠。base/pv-min プログラム（L1 等）は turbo86 系で実 x86 に流せる。pv-kernel Linux はその system 版（qemu machine / KVM）が要る。
-
-### substrate の必須要件（conformance gate, round-3）
-
-「薄い」は計算が native という意味で、substrate 自体には正確さが要る：
-
-1. **命令 whitelist の強制**（最重要）: x86 に "mov-only モード" は無い。guest が ring0 native 実行する以上、紛れ込んだ非-mov 命令は実 x86 意味論で動いてしまう。→ **boot 前の静的検証**（イメージ全体が許可命令のみか）か **検証済みページにのみ実行権限**を与える方式が必要。コンパイラを信頼するだけでは機械 conformance にならない。
-2. **正確な i386 `mov` デコーダ**: PV-MMIO を not-present #PF + 命令デコードで捕える方式は、ModRM/SIB/disp/幅/方向/実効アドレスを正しく解く mov デコーダを要する（full x86 decode は不要だが正確さ必須）。
-3. **EIP 前進 vs 再実行の規則**: MMIO エミュレーションは faulting 命令を再実行せず、結果を合成して **EIP を mov の次へ前進**。真の page fault は **EIP を faulting 命令に残す**。この区別を substrate spec に明記。
-4. **host 例外の完全隠蔽**: EFLAGS 無し trap frame（spec §6.3）が成立するのは、許可 guest 命令が flags を観測しないから。host の timer IRQ・#PF・#UD は x86mov32 trap frame に翻訳するか substrate バグ扱い。`popf`/`pushf`/`lahf`/`cmovcc`/string ops 等は **whitelist で排除されている**ことが前提。
-5. **PV アクセスは高コスト exit**: #PF+decode は稀な制御（MMU 設定・console char・timer・`PGDIR`・`IRET`）には十分だが **高頻度 I/O には不可**。高頻度経路は実 MMIO ページを直接マップする等の最適化が要る。near-native なのは計算であって PV 境界ではない。
-6. **分離**: bare-metal monitor 形態は、guest と substrate が同 ring だと guest が substrate のページテーブル/IDT/GDT/実行マップを壊せて崩壊する。実質 **micro-hypervisor**（qemu/KVM 境界の方がクリーン）。
-7. **SMC**: native 実行が妥当なのは W^X + テキストパッチ無効化の config か、PV-TEXTPATCH の host 承認プロトコル経由のときだけ（spec §5/§7.8）。
-
-> L0/L1 を movie86 で固めた後、上記 gate を満たす qemu machine type で L8 として実機経路を実証する。
-
-## 4. PV scope（spec §2 との整合 — 0.1 の矛盾を解消）
-
-spec は profile 定義（pv-kernel は PV-CPU/IRQ/MMU を *含む*）、本書はその **実装の段階**を定める。両者は別物：
-
-- **実装が先行するのは pv-min（console+timer）まで**（L0–L1）。
-- **pv-kernel（PV-CPU/IRQ/MMU・trap 配送）は spec で named + reserved 済み、実装は L2/L5/L6 で順次**。
-- 「console+timer のみ」は *いま実装する PV* の話であって、profile 定義の縮小ではない（0.1-draft の文言ミスを訂正）。
-
-## 5. リスクと未決事項
-
-- **R1（最大）**: コンパイラ/カーネル意味論互換性。inline asm は氷山の一角（compiler barrier・`asm goto`・exception-table fixup・object layout…）。→ L0.5 kill-test で早期に殺す。
-- **R2**: llvm-mov の inline asm 実装コスト不明。L3 を L0.5 の優先順で段階導入。
-- **R3（host 間乖離）**: PV を movie86 だけが持つと「movie86 で動くが x86-host で落ちる」。→ (a) fault を x86-like に固定（spec §6.1）、(b) PV/プラットフォームを named profile + x86-host 実行層として明示（spec §2）、(c) conformance fixture を両 host で通す CI ゲート（spec §8）。
-- **R4（解消）**: movie86 の機械化で userspace ランナーの単純さを失う点は、**AS-IS 互換が非ゴール（best-effort ですらない）**ため問題にしない（design 決定）。movie86 を x86mov32 リファレンス機械へ自由に再形成してよい（flat メモリ→interval map、userspace runner→機械、特権状態の追加）。**旧 movfuscator 実行・`0x1FFE_0000` ABI を残す義務はなく、既存 movfuscator/wasm/explorer が壊れることは許容**。残る配慮は「再形成を段階的に行い各ステージを緑に保つ」ことだけ。
-- **R5（テキストパッチ）**: Linux の alternatives/static-keys/ftrace/kprobes/paravirt-patch は自己書き換え（spec §5 で base 不許可）。→ PV-TEXTPATCH（spec §7.8）か「対象 config で全テキスト改変無効化」のいずれか。L0.5 で現実性を判定。
-
-## 6. 即時の design TODO
-
-- [x] TODO-1: **決定** — pv-min console は spec アドレス `0x1FF0_1000`（PV-CONSOLE）。**movfuscator 互換は非ゴール**なので PV-MMIO 窓は完全に自由設計。legacy `0x1FFE_0000` は予約も共存もしない（spec §2 design stance / §7.1）
-- [ ] TODO-2: 割り込み配送モデル（poll 型 → 強制ジャンプ型）の境界確定（spec §7.6）
-- [ ] TODO-3: ページテーブル形式（x86 PTE 流用可否）を L0.5 結果で判断（spec §7.7）
-- [x] TODO-4: **決定 — 自作の極小カーネル**（L1, inline asm 非依存）
-- [x] TODO-5: **決定 — 実装は最小 PV(console+timer)先行**、pv-kernel は spec 予約・段階実装（§4）
-- [x] TODO-6: **決定 — 新アーキ `arch/x86mov32/` として移植**（arch/x86 流用せず, §1）
-- [x] TODO-7: **決定 — ターゲット名 `x86mov32`**
-- [x] TODO-8: **決定 — 主 template は arch/riscv(rv32)**。trap/CLINT/PLIC/SBI/DT を移植参考に（§1, spec §6.3/§7.4–§7.6/§7.10）
-- [x] TODO-9: **決定 — ハードウェア記述は device tree**。boot で DTB を渡す（spec §7.10/§9）
-- [x] TODO-10: **L0.5 kill-test 完了** → [`L0.5-KILLTEST.md`](./L0.5-KILLTEST.md)（二者独立検証, SURVIVES）。llvm-mov 要件と最小 config を確定
-- [ ] TODO-11: PV-* の DT binding（compatible 文字列・reg・interrupts）を起こす（spec §7.10）
-- [ ] TODO-12: arch/x86mov32 の defconfig 起点（SMP=n / PREEMPT_NONE / nommu uaccess / JUMP_LABEL=n / no ALTERNATIVE/FTRACE/KPROBES / GENERIC_ATOMIC64 / GENERIC_LIB_* / 無印 BUG）を起こす（L0.5 §ロードマップ帰結）
+- TRAP_STACK の nested trap / mask 順（L2）
+- PV-* の device tree binding（compatible / reg / interrupts）
+- arch/x86mov32 の defconfig 起点（SMP=n / PREEMPT_NONE / nommu uaccess / JUMP_LABEL=n / no ALTERNATIVE・FTRACE・KPROBES / GENERIC_ATOMIC64 / GENERIC_LIB_* / 無印 BUG）
+- substrate の非-mov スタブ命令集合

--- a/linux-mov/DESIGN.md
+++ b/linux-mov/DESIGN.md
@@ -130,12 +130,12 @@ spec は profile 定義（pv-kernel は PV-CPU/IRQ/MMU を *含む*）、本書�
 - **R1（最大）**: コンパイラ/カーネル意味論互換性。inline asm は氷山の一角（compiler barrier・`asm goto`・exception-table fixup・object layout…）。→ L0.5 kill-test で早期に殺す。
 - **R2**: llvm-mov の inline asm 実装コスト不明。L3 を L0.5 の優先順で段階導入。
 - **R3（host 間乖離）**: PV を movie86 だけが持つと「movie86 で動くが x86-host で落ちる」。→ (a) fault を x86-like に固定（spec §6.1）、(b) PV/プラットフォームを named profile + x86-host 実行層として明示（spec §2）、(c) conformance fixture を両 host で通す CI ゲート（spec §8）。
-- **R4（緩和）**: movie86 の機械化で userspace ランナーの単純さを失う点は、**AS-IS 維持が制約でない**ため許容（design 決定）。movie86 を x86mov32 リファレンス機械へ自由に再形成してよい（flat メモリ→interval map、userspace runner→機械、特権状態の追加）。既存 movfuscator/wasm/explorer 互換は best-effort の optional legacy モードで設計を縛らない。残る配慮は「再形成を段階的に行い各ステージを緑に保つ」ことだけ。
+- **R4（解消）**: movie86 の機械化で userspace ランナーの単純さを失う点は、**AS-IS 互換が非ゴール（best-effort ですらない）**ため問題にしない（design 決定）。movie86 を x86mov32 リファレンス機械へ自由に再形成してよい（flat メモリ→interval map、userspace runner→機械、特権状態の追加）。**旧 movfuscator 実行・`0x1FFE_0000` ABI を残す義務はなく、既存 movfuscator/wasm/explorer が壊れることは許容**。残る配慮は「再形成を段階的に行い各ステージを緑に保つ」ことだけ。
 - **R5（テキストパッチ）**: Linux の alternatives/static-keys/ftrace/kprobes/paravirt-patch は自己書き換え（spec §5 で base 不許可）。→ PV-TEXTPATCH（spec §7.8）か「対象 config で全テキスト改変無効化」のいずれか。L0.5 で現実性を判定。
 
 ## 6. 即時の design TODO
 
-- [x] TODO-1: **決定** — pv-min console は spec アドレス `0x1FF0_1000`（PV-CONSOLE）。**movie86 AS-IS は維持制約でない**ため PV-MMIO 窓は自由に設計でき、legacy `0x1FFE_0000` の共存は必須でなく best-effort（compat-movfuscator が要るときだけ供給, spec §2 design stance）
+- [x] TODO-1: **決定** — pv-min console は spec アドレス `0x1FF0_1000`（PV-CONSOLE）。**movfuscator 互換は非ゴール**なので PV-MMIO 窓は完全に自由設計。legacy `0x1FFE_0000` は予約も共存もしない（spec §2 design stance / §7.1）
 - [ ] TODO-2: 割り込み配送モデル（poll 型 → 強制ジャンプ型）の境界確定（spec §7.6）
 - [ ] TODO-3: ページテーブル形式（x86 PTE 流用可否）を L0.5 結果で判断（spec §7.7）
 - [x] TODO-4: **決定 — 自作の極小カーネル**（L1, inline asm 非依存）

--- a/linux-mov/DESIGN.md
+++ b/linux-mov/DESIGN.md
@@ -78,6 +78,25 @@ PV 境界は稀なので計算は全速・仲介は薄い。
 1. **qemu machine type `x86mov32`**（推奨）: guest=mov カーネル、qemu が PV-MMIO デバイス + 割り込み注入を提供。movie86 と qemu がこの spec の2実装になり conformance（spec §8）に乗る。
 2. **bare-metal monitor**: 実機 ring0 最小 firmware。純度最高だが手間。
 
+### substrate の正体 = OpenSBI 相当の薄い特権ファームウェア
+
+substrate は RISC-V の **OpenSBI（M-mode ランタイム）に相当する薄い ring0 特権レイヤ**。カーネルが特権サービスを S-mode→M-mode `ecall` で頼むのと同様に、x86mov32 ではカーネルが PV-MMIO へ `mov` したのを substrate が処理する。非-mov の特権命令（`lidt`/`mov CR3`/`sti`/`iret`/boot）はここに **隔離**され、カーネルは 100% mov のまま native 実行される。
+
+- **movie86 はこの役割をソフト（Rust）で兼ねる**ので別途 substrate 不要（movie86 = 機械）。substrate が要るのは実 x86 host のときだけ。
+- 決定的差: **movie86 は命令を*解釈*（インタプリタ）／ substrate は CPU に mov を*native 実行*させ稀な PV 境界だけ仲介**（薄い）。計算は全速。
+
+### substrate 自体の mov 化
+
+substrate の仕事の大半は **純計算** — faulting `mov` のデコード（ModRM/SIB/disp/幅）、trap frame（spec §6.3）構築、ゲストメモリ/レジスタ操作、whitelist 検証、EIP 前進。**これらは全て mov 化でき、llvm-mov でコンパイルできる**。
+
+irreducible に非-mov なのは **X86-DELTA §4 の M セットそのもの** = `lgdt`/`lidt`/`mov CRn`/`sti`/`cli`/`iret`/`invlpg` + real-mode boot stub（port I/O は MMIO デバイス採用で回避可）。数十命令オーダーの固定スタブ。
+
+→ **substrate = mov-heavy（llvm-mov 製）+ 最小の非-mov 特権スタブ**。これは会話初期の「mov-heavy + 小さな asm shim」を、*カーネル全体ではなく substrate に正しくスコープした*もの。美しい閉包: x86mov32 がカーネルから追い出した特権は、最小化されて substrate の小さな非-mov 核として再出現する。ゼロにはできない（X86-DELTA の結論）が周辺は全部 mov にできる。
+
+2つの哲学:
+- **実用（qemu/KVM）**: substrate = 既存の大きな非-mov ソフト（qemu/KVM/host Linux）。簡単だが mov でない。
+- **純粋（bare-metal mov-heavy monitor）**: llvm-mov 製 monitor + 最小非-mov スタブ。最大限 mov・プロジェクトの美学に一致。← 「substrate も mov 化」の到達目標。
+
 **既存資産**: turbo86（ptrace で mov バイナリを実 x86 に native 実行 + trap）は **userspace 版 x86-host 実行層**が既にある証拠。base/pv-min プログラム（L1 等）は turbo86 系で実 x86 に流せる。pv-kernel Linux はその system 版（qemu machine / KVM）が要る。
 
 ### substrate の必須要件（conformance gate, round-3）

--- a/linux-mov/DESIGN.md
+++ b/linux-mov/DESIGN.md
@@ -42,10 +42,11 @@ x86mov32 を独立 base ISA と定義した（spec §1）以上、Linux 側も *
 | Stage | profile | 内容 | 緑の判定 |
 |---|---|---|---|
 | **L0** | pv-min | movie86 に PV-MMIO ウィンドウ + PV-CONSOLE(`PUTC`)。spec §6.1 の x86-like 同期 fault（未マップ=fault）も実装 | 別 PV ページへの mov が console handler に届く単体 + base/pv-min conformance fixture（spec §8） |
-| **L0.5** | — | **Linux/x86mov32 feasibility kill-test**（コード変更なし）。実 Linux ソースに対し inline asm 形態・**`asm goto`・`"memory"` clobber・exception-table/fault fixup**・atomics・builtins・special sections・linker script・varargs/i64 を棚卸し。**kill 条件**: llvm-mov がコンパイラバリア + faultable asm/制御フロー fixup をモデル化できないと判明したら、ロードマップを再設計（atomics より先に詰む論点） | blocking list が spec 0.3 入力として確定 |
+| **L0.5** ✅ | — | **Linux/x86mov32 feasibility kill-test** → 結果 [`L0.5-KILLTEST.md`](./L0.5-KILLTEST.md)。**判定 SURVIVES**（二者独立検証）。config レベル BLOCKER なし（UP/nommu/no-SMC/no-jumplabel で難所は全て無効化 or 純 C 化）。残るは llvm-mov の限定作業（volatile codegen・空+operand バリア・i386 varargs・i64 helper lower・C irq-flag）。任意 inline asm は first boot 不要 | 完了 |
 | **L1** | pv-min | 自作極小カーネル（数百行 C, **inline asm 不使用**）を llvm-mov でビルドし `PUTC` に mov して `"Hello, x86mov32\n"` を出して停止 | E2E: ELF を movie86 で実行→期待出力。objdump で `.text` が mov(+jmp) のみ |
 | **L2** | pv-kernel | PV-CPU(`INTR_MASK`/`IDT_BASE`/`IRET`) + spec §6.3 trap frame + poll 型 PV-IRQ。協調スケジューラの土台 | trap frame 往復 / マスク制御 / tick 単体 + E2E + pv-kernel conformance（一部） |
-| **L3** | — | llvm-mov に **inline asm → mov**（mainline への分水嶺）。L0.5 の blocking list 順で、まず単純制約→`"memory"`/volatile→`asm goto` | 新規 inline-asm fixture が mov-only で通る |
+| **L3a** | — | **first boot 必須のコンパイラ作業**（L0.5 確定）: volatile load/store の codegen 正しさ、空+operand 付き memory バリア、i386 SysV varargs、i64 helper-call lower（除算は do_div 経由で libgcc 除算を emit しない）、memcpy/memset emit、C `arch_local_irq_save/restore` | 各 fixture が mov-only で通る |
+| **L3b** | — | **任意制約 inline asm → mov**（広い config / driver 用、first boot 不要に後退）。段階導入、対応不能形を列挙 | inline-asm fixture |
 | **L4** | — | atomics（UP 前提で `lock` 省略 + cmpxchg を mov 列に） | atomic fixture |
 | **L5** | pv-kernel | PV-MMU(`PGDIR`/`FLUSH`/`FAULT_ADDR`) + `PagedMemory`。demand paging / page fault 配送（spec §6.2/§7.7） | page fault → FAULT_ADDR / PGDIR で VA→PA |
 | **L6** | pv-kernel | 強制ジャンプ型割り込み（preemption） | タイマで別タスクへ切替 |
@@ -120,5 +121,6 @@ spec は profile 定義（pv-kernel は PV-CPU/IRQ/MMU を *含む*）、本書�
 - [x] TODO-7: **決定 — ターゲット名 `x86mov32`**
 - [x] TODO-8: **決定 — 主 template は arch/riscv(rv32)**。trap/CLINT/PLIC/SBI/DT を移植参考に（§1, spec §6.3/§7.4–§7.6/§7.10）
 - [x] TODO-9: **決定 — ハードウェア記述は device tree**。boot で DTB を渡す（spec §7.10/§9）
-- [ ] TODO-10: L0.5 kill-test の具体的チェックリストと判定基準を起こす（arch/riscv の inline asm/atomics/fixup の使い方も比較参照点に）（spec §10 → 0.3）
+- [x] TODO-10: **L0.5 kill-test 完了** → [`L0.5-KILLTEST.md`](./L0.5-KILLTEST.md)（二者独立検証, SURVIVES）。llvm-mov 要件と最小 config を確定
 - [ ] TODO-11: PV-* の DT binding（compatible 文字列・reg・interrupts）を起こす（spec §7.10）
+- [ ] TODO-12: arch/x86mov32 の defconfig 起点（SMP=n / PREEMPT_NONE / nommu uaccess / JUMP_LABEL=n / no ALTERNATIVE/FTRACE/KPROBES / GENERIC_ATOMIC64 / GENERIC_LIB_* / 無印 BUG）を起こす（L0.5 §ロードマップ帰結）

--- a/linux-mov/L0.5-KILLTEST.md
+++ b/linux-mov/L0.5-KILLTEST.md
@@ -1,0 +1,64 @@
+# L0.5 — Linux/x86mov32 feasibility kill-test 結果
+
+> 実 Linux ソース（torvalds/linux, shallow+sparse: arch/riscv・include/linux・include/asm-generic・kernel・lib・mm・init）に対する経験的棚卸し。観点: 「inline asm/atomics/varargs/native i64 を持たない mov-only backend が、UP・no-preempt・nommu・no-SMC の最小 config を、arch/riscv(rv32) を template に移植できるか」。
+
+## 判定: **SURVIVES**（致命要因なし）
+
+config レベルの **hard BLOCKER は無い**。カーネルが要求する難所（asm goto・exception table・atomics・text patching・特殊セクション）は **すべて無効化、または純 C の generic 経路に落とせる** — 32bit-riscv + UP + nommu + asm-generic のスタックが既に存在するため。
+
+ボトルネックは **カーネルの機能集合ではなく llvm-mov 側の限定的な作業**に移る。しかも **任意の inline asm は first boot には不要**（最大の de-risking）。
+
+> **二者独立検証**: 本判定は2つの独立した kill-test（汎用調査エージェント + smart-friend/codex を同一ソースに対し別個に実行）で **両者とも SURVIVES** に到達。codex は「空バリアだけ」を *operand 付きバリア + volatile codegen 正しさ + i64 除算の注意 + entry は link 必須* に締め直した（下記反映済み）。観点は概ね収束しており、致命的な相違は出なかった。
+
+## カテゴリ別（証拠は実ソース file:line）
+
+| # | 項目 | 判定 | 根拠 / 回避策 |
+|---|---|---|---|
+| 1 | `barrier()` / memory-clobber asm + volatile アクセス | **要コンパイラ対応（必須）** | `include/linux/compiler.h:85` 空 `__asm__ __volatile__("":::"memory")`。**加えて（codex 補正）** `barrier_data(ptr)`（`compiler.h:88-103`, `string.h` の `memzero_explicit` が使用）は **operand 付き** `asm volatile("":"r"(ptr):"memory")`、`OPTIMIZER_HIDE_VAR`（`compiler.h:157-161`）は tied operand。さらに `READ_ONCE/WRITE_ONCE`（`asm-generic/rwonce.h:43-62`）は inline asm でないが **volatile load/store を merge/refetch しない codegen 保証**が要る。config で消せない。マクロ override は可能だが結局同じ意味論を負う。 |
+| 2 | `asm goto` / static keys | **config 無効化可** | `HAVE_ARCH_JUMP_LABEL` を select しない → `include/linux/jump_label.h:241` 以降の純 C fallback（`atomic_read` ベース）。 |
+| 3 | exception table / uaccess fixup | **config/arch 選択で回避** | `include/asm-generic/uaccess.h:82` の `raw_copy_*_user`＝`memcpy`。`__ex_table` は空のまま残るが無害。復帰可能な user-copy fault を諦める nommu 流。 |
+| 4 | atomics | **config 無効化 + 小コンパイラ作業** | `CONFIG_SMP=n` で `include/asm-generic/cmpxchg-local.h:15` の純 C cmpxchg（IRQ マスク→load/compare/store→unmask）。必要なのは C の `arch_local_irq_save/restore` のみ（`asm-generic/irqflags.h:20` が C 関数を許可）。atomic64 は `lib/atomic64.c` の spinlock 実装（`GENERIC_ATOMIC64`）。**最も有利な発見**。 |
+| 5 | libgcc helper / i64 / memcpy | **要コンパイラ対応（容易、除算に注意）** | i64 shift/mul は `lib/{ashldi3,lshrdi3,muldi3}.c`（`GENERIC_LIB_*`）への call。memcpy/memset call を emit。**除算の落とし穴（codex 補正）**: `__divdi3/__udivdi3/__moddi3/__umoddi3` は generic helper に**無い**。カーネルは `do_div`/`div_u64`（`asm-generic/div64.h`）で生の u64 除算を避ける設計。backend は **libgcc 除算 call を emit しない**（do_div 経由を保つ）か自前供給が必要。native i64 不要。 |
+| 6 | linker section | **config 無効化可** | 必須セクション（TEXT/INIT/EXIT/RODATA/DATA/BSS/PERCPU + 空 `__ex_table`）は **SMC を含意しない**。`.alternative`・`RUNTIME_CONST` を select しないだけ。 |
+| 7 | text patching（ALT/JUMP_LABEL/FTRACE/KPROBES） | **config 無効化可** | 全て arch-Kconfig で off 可。riscv は `RISCV_ALTERNATIVE` を強制 select するが、**我々はその select 行を写さない**。no-SMC config が作れる。 |
+| 8 | varargs / per-cpu | varargs **要コンパイラ対応（必須）** / per-cpu **自明** | printk は全 build で varargs（`lib/vsprintf.c` の `va_list`）。i386 SysV varargs（スタックベース、`va_list`=`char*`）の実装が必須・config で消せない。per-cpu は generic（`asm-generic/percpu.h:45`）の純 C ポインタ算術、UP では固定オフセット。 |
+| 9 | BUG()/WARN() | **config 選択で C 経路（codex 補正）** | `GENERIC_BUG` を select すると arch の trap 命令 + handler が要る（`lib/bug.c:17-36`）。代わりに無印 `asm-generic/bug.h:72-78` の C 経路（`printk`+`panic`）を使う。WARN は varargs 依存（§8 でカバー）。static_call も `HAVE_STATIC_CALL=n` で関数ポインタ fallback（`static_call.h:286`）→ SMC 不要。 |
+
+## irreducible な要件（config で消せない）= llvm-mov の到達目標
+
+二者の独立 kill-test を統合した最終リスト（codex 補正後）：
+
+1. **volatile アクセスの codegen 正しさ** — `READ_ONCE/WRITE_ONCE`（`rwonce.h`）が要求する「volatile load/store を merge/refetch しない」保証（§1）。
+2. **コンパイラバリア（空 + operand 付き）** — `asm volatile("":::"memory")`（barrier）と `asm volatile("":"r"(x):"memory")`（barrier_data）、tied operand（OPTIMIZER_HIDE_VAR）を、命令を出さず並べ替え/別名最適化を抑止するものとして認識（§1）。← *任意* inline asm ではないが、空形だけでは不足。
+3. **i386 SysV varargs**（`va_list`/`va_arg`）を printk のために実装（§8）。i386 は全引数スタック渡しで最も単純。
+4. **i64 helper lowering（除算に注意）** — shift/mul は `lib` の C helper call。**libgcc 除算 call を emit しない**（do_div 経由）か自前供給（§5）。memcpy/memset emit。
+5. **C/PV の irq-flag 意味論** — UP atomics を支える `arch_local_irq_save/restore`（C 関数 = PV mov で可）が割り込みマスク窓を保証（§4）。
+
+**重要**: 私が当初「mainline への 6〜12ヶ月の分水嶺」と見積もった *任意 inline asm → mov*（旧 L3）は、**first boot には不要**。最小 config が要求する inline asm は空＋operand 付きバリアのみで、任意制約 inline asm はドライバや広い config の段階（L3b）に後退する。これが最大の de-risking。
+
+## 最後に残る真の難所：entry/特権パス（= PV 境界、link/boot 必須）
+
+kill-test のサブセット外だが本質的、かつ **設計注ではなく link/boot の必須要件**（codex 強調）: riscv は `head.o`/`entry.o` を無条件ビルドし（`arch/riscv/kernel/Makefile:49-54`）、`head.S:_start`（`head.S:20-37`）・`entry.S` の trap/irq 入口（`entry.S:21-85`）が無いと **link も boot もしない**。最早期 boot/entry（trap vector 設置・MMU/`satp` 設定・context-switch のレジスタ退避）は riscv では **genuinely irreducible な手書き `.S`**。「100% mov」が実際に破れるのはここ。
+
+ただしこれは **X86-DELTA.md §4 の M クラス（特権操作）そのもの**であり、x86mov32 では **PV-MMIO mov に写像済み**：
+
+- trap vector 設置 → PV-CPU `IDT_BASE` への mov
+- MMU 設定 → PV-MMU `PGDIR` への mov
+- context-switch のレジスタ退避/復帰 → trap frame（spec §6.3）への mov 列 / PV `IRET`
+
+つまり entry stub は「特権命令」ではなく「**PV レジスタへの mov 列**」として書ける。手書きの mov 列（`arch/x86mov32` の entry）になるか、llvm-mov が PV mov を emit する形になるかは実装選択だが、**新たな irreducible 特権命令は増えない**。delta 分析と整合する。
+
+## ロードマップへの帰結
+
+- **旧 L3「任意 inline asm → mov」を分割**:
+  - **L3a（first boot 必須・小）**: 空 memory-clobber バリア + i386 varargs + i64 helper-call lowering + memcpy/memset emit。
+  - **L3b（後続・広い config / driver 用）**: 一般的な制約付き inline asm。
+- **最小 config を確定**: `SMP=n` / `PREEMPT_NONE` / nommu uaccess / `JUMP_LABEL=n` / no `RISCV_ALTERNATIVE` 相当 / no FTRACE/KPROBES / `GENERIC_ATOMIC64` / `GENERIC_LIB_*`。これを arch/x86mov32 の defconfig 起点にする。
+- **entry stub** は PV mov 列として `arch/x86mov32` に手書きできる（trap frame §6.3 / PV-CPU / PV-MMU）。
+
+## 残リスク（正直に）
+
+- 本 kill-test は arch/riscv + core の static 棚卸し。実ビルドで *他の* 必須 inline asm 形が露出する可能性は残る（L3a で逐次対応、対応不能形は早期に列挙）。
+- 空バリアと varargs は llvm-mov に **新規サブシステム**（現状ゼロ）。「小」は任意 inline asm 比であって、ゼロではない。
+- entry stub の mov 列の正しさ（trap frame の原子的退避/復帰）は実装で詰める。
+- これは *最小 config* の話。shell/userspace/driver へ広げると inline asm 面（L3b）と atomics/SMP が再浮上する。

--- a/linux-mov/L0.5-KILLTEST.md
+++ b/linux-mov/L0.5-KILLTEST.md
@@ -1,64 +1,44 @@
-# L0.5 — Linux/x86mov32 feasibility kill-test 結果
+# L0.5 — Linux/x86mov32 feasibility kill-test
 
-> 実 Linux ソース（torvalds/linux, shallow+sparse: arch/riscv・include/linux・include/asm-generic・kernel・lib・mm・init）に対する経験的棚卸し。観点: 「inline asm/atomics/varargs/native i64 を持たない mov-only backend が、UP・no-preempt・nommu・no-SMC の最小 config を、arch/riscv(rv32) を template に移植できるか」。
+実 Linux ソース（torvalds/linux: arch/riscv・include・kernel・lib・mm）に対する経験的棚卸し。観点は「inline asm/atomics/varargs/native i64 を持たない mov-only backend が、UP・no-preempt・nommu・no-SMC の最小 config を `arch/riscv`(rv32) を template に移植できるか」。2つの独立した調査で実施し、両者とも下記結論に到達した。
 
-## 判定: **SURVIVES**（致命要因なし）
+## 判定: SURVIVES
 
-config レベルの **hard BLOCKER は無い**。カーネルが要求する難所（asm goto・exception table・atomics・text patching・特殊セクション）は **すべて無効化、または純 C の generic 経路に落とせる** — 32bit-riscv + UP + nommu + asm-generic のスタックが既に存在するため。
+最小 config にカーネル側の **config レベル阻害要因は無い**。難所（asm goto・exception table・atomics・text patching・特殊セクション）はすべて無効化、または純 C の generic 経路に落とせる — 32bit-riscv + UP + nommu + asm-generic のスタックが既に存在するため。ボトルネックは **カーネルの機能集合ではなく llvm-mov 側の限定的な作業**に移り、**任意の inline asm は first boot には不要**。
 
-ボトルネックは **カーネルの機能集合ではなく llvm-mov 側の限定的な作業**に移る。しかも **任意の inline asm は first boot には不要**（最大の de-risking）。
+## カテゴリ別（file:line は実ソース）
 
-> **二者独立検証**: 本判定は2つの独立した kill-test（汎用調査エージェント + smart-friend/codex を同一ソースに対し別個に実行）で **両者とも SURVIVES** に到達。codex は「空バリアだけ」を *operand 付きバリア + volatile codegen 正しさ + i64 除算の注意 + entry は link 必須* に締め直した（下記反映済み）。観点は概ね収束しており、致命的な相違は出なかった。
+| 項目 | 判定 | 根拠 / 回避策 |
+|---|---|---|
+| `barrier()` / volatile アクセス | 要コンパイラ対応（必須）| `compiler.h:85` 空 `asm volatile("":::"memory")`。加えて `barrier_data` は operand 付き、`READ_ONCE/WRITE_ONCE` は volatile load/store を merge/refetch しない codegen 保証。config で消せない |
+| `asm goto` / static keys | config 無効化可 | `HAVE_ARCH_JUMP_LABEL` を select しない → 純 C fallback（`jump_label.h:241`）|
+| exception table / uaccess fixup | config/arch 選択で回避 | `asm-generic/uaccess.h:82` の memcpy 経路。`__ex_table` は空で無害 |
+| atomics | config + 小コンパイラ作業 | `SMP=n` で純 C cmpxchg（IRQ マスク）。必要なのは C の `arch_local_irq_save/restore` のみ。atomic64 は `lib/atomic64.c`（`GENERIC_ATOMIC64`）。最も有利 |
+| libgcc / i64 / memcpy | 要コンパイラ対応（容易、除算注意）| shift/mul は `lib/*.c`（`GENERIC_LIB_*`）。`__divdi3` 等は未出荷 → libgcc 除算を emit しない（`do_div` 経由）か自前供給 |
+| linker section | config 無効化可 | 必須セクションは SMC を含意しない。`.alternative` 等を select しない |
+| text patching（ALT/JL/FTRACE/KPROBES）| config 無効化可 | 全て arch-Kconfig で off。riscv は ALTERNATIVE を強制 select するが我々は写さない |
+| varargs / per-cpu | varargs 必須 / per-cpu 自明 | printk は全 build で varargs（i386 SysV は単純）。per-cpu は generic な純 C、UP では固定オフセット |
+| BUG/WARN | config 選択で C 経路 | 無印 `asm-generic/bug.h` の C 経路（printk+panic）。`GENERIC_BUG`（trap 命令要）は避ける |
 
-## カテゴリ別（証拠は実ソース file:line）
+## llvm-mov の必須要件（config で消せない）
 
-| # | 項目 | 判定 | 根拠 / 回避策 |
-|---|---|---|---|
-| 1 | `barrier()` / memory-clobber asm + volatile アクセス | **要コンパイラ対応（必須）** | `include/linux/compiler.h:85` 空 `__asm__ __volatile__("":::"memory")`。**加えて（codex 補正）** `barrier_data(ptr)`（`compiler.h:88-103`, `string.h` の `memzero_explicit` が使用）は **operand 付き** `asm volatile("":"r"(ptr):"memory")`、`OPTIMIZER_HIDE_VAR`（`compiler.h:157-161`）は tied operand。さらに `READ_ONCE/WRITE_ONCE`（`asm-generic/rwonce.h:43-62`）は inline asm でないが **volatile load/store を merge/refetch しない codegen 保証**が要る。config で消せない。マクロ override は可能だが結局同じ意味論を負う。 |
-| 2 | `asm goto` / static keys | **config 無効化可** | `HAVE_ARCH_JUMP_LABEL` を select しない → `include/linux/jump_label.h:241` 以降の純 C fallback（`atomic_read` ベース）。 |
-| 3 | exception table / uaccess fixup | **config/arch 選択で回避** | `include/asm-generic/uaccess.h:82` の `raw_copy_*_user`＝`memcpy`。`__ex_table` は空のまま残るが無害。復帰可能な user-copy fault を諦める nommu 流。 |
-| 4 | atomics | **config 無効化 + 小コンパイラ作業** | `CONFIG_SMP=n` で `include/asm-generic/cmpxchg-local.h:15` の純 C cmpxchg（IRQ マスク→load/compare/store→unmask）。必要なのは C の `arch_local_irq_save/restore` のみ（`asm-generic/irqflags.h:20` が C 関数を許可）。atomic64 は `lib/atomic64.c` の spinlock 実装（`GENERIC_ATOMIC64`）。**最も有利な発見**。 |
-| 5 | libgcc helper / i64 / memcpy | **要コンパイラ対応（容易、除算に注意）** | i64 shift/mul は `lib/{ashldi3,lshrdi3,muldi3}.c`（`GENERIC_LIB_*`）への call。memcpy/memset call を emit。**除算の落とし穴（codex 補正）**: `__divdi3/__udivdi3/__moddi3/__umoddi3` は generic helper に**無い**。カーネルは `do_div`/`div_u64`（`asm-generic/div64.h`）で生の u64 除算を避ける設計。backend は **libgcc 除算 call を emit しない**（do_div 経由を保つ）か自前供給が必要。native i64 不要。 |
-| 6 | linker section | **config 無効化可** | 必須セクション（TEXT/INIT/EXIT/RODATA/DATA/BSS/PERCPU + 空 `__ex_table`）は **SMC を含意しない**。`.alternative`・`RUNTIME_CONST` を select しないだけ。 |
-| 7 | text patching（ALT/JUMP_LABEL/FTRACE/KPROBES） | **config 無効化可** | 全て arch-Kconfig で off 可。riscv は `RISCV_ALTERNATIVE` を強制 select するが、**我々はその select 行を写さない**。no-SMC config が作れる。 |
-| 8 | varargs / per-cpu | varargs **要コンパイラ対応（必須）** / per-cpu **自明** | printk は全 build で varargs（`lib/vsprintf.c` の `va_list`）。i386 SysV varargs（スタックベース、`va_list`=`char*`）の実装が必須・config で消せない。per-cpu は generic（`asm-generic/percpu.h:45`）の純 C ポインタ算術、UP では固定オフセット。 |
-| 9 | BUG()/WARN() | **config 選択で C 経路（codex 補正）** | `GENERIC_BUG` を select すると arch の trap 命令 + handler が要る（`lib/bug.c:17-36`）。代わりに無印 `asm-generic/bug.h:72-78` の C 経路（`printk`+`panic`）を使う。WARN は varargs 依存（§8 でカバー）。static_call も `HAVE_STATIC_CALL=n` で関数ポインタ fallback（`static_call.h:286`）→ SMC 不要。 |
+1. **volatile アクセスの codegen 正しさ**（`READ_ONCE/WRITE_ONCE`）
+2. **コンパイラバリア**（空 `asm volatile("":::"memory")` + operand 付き `barrier_data`）を、命令を出さず並べ替え/別名最適化を抑止するものとして認識
+3. **i386 SysV varargs**（`va_list`/`va_arg`、スタックベースで単純）
+4. **i64 helper lower**（shift/mul は lib の C helper call、libgcc 除算は emit しない）+ memcpy/memset emit
+5. **C/PV の `arch_local_irq_save/restore`**（UP atomics の割り込みマスク窓）
 
-## irreducible な要件（config で消せない）= llvm-mov の到達目標
+任意制約の inline asm（旧 L3）は first boot には不要で、広い config / driver の段階（L3b）に後退する。これが最大の de-risking。
 
-二者の独立 kill-test を統合した最終リスト（codex 補正後）：
+## entry/特権パス（link/boot 必須）
 
-1. **volatile アクセスの codegen 正しさ** — `READ_ONCE/WRITE_ONCE`（`rwonce.h`）が要求する「volatile load/store を merge/refetch しない」保証（§1）。
-2. **コンパイラバリア（空 + operand 付き）** — `asm volatile("":::"memory")`（barrier）と `asm volatile("":"r"(x):"memory")`（barrier_data）、tied operand（OPTIMIZER_HIDE_VAR）を、命令を出さず並べ替え/別名最適化を抑止するものとして認識（§1）。← *任意* inline asm ではないが、空形だけでは不足。
-3. **i386 SysV varargs**（`va_list`/`va_arg`）を printk のために実装（§8）。i386 は全引数スタック渡しで最も単純。
-4. **i64 helper lowering（除算に注意）** — shift/mul は `lib` の C helper call。**libgcc 除算 call を emit しない**（do_div 経由）か自前供給（§5）。memcpy/memset emit。
-5. **C/PV の irq-flag 意味論** — UP atomics を支える `arch_local_irq_save/restore`（C 関数 = PV mov で可）が割り込みマスク窓を保証（§4）。
+riscv は `head.o`/`entry.o` を無条件ビルドし、`head.S:_start` と `entry.S` の trap 入口が無いと link も boot もしない。最早期 boot/entry（trap vector 設置・MMU 設定・context-switch のレジスタ退避）は riscv では手書き `.S` で、「100% mov」が破れる場所。
 
-**重要**: 私が当初「mainline への 6〜12ヶ月の分水嶺」と見積もった *任意 inline asm → mov*（旧 L3）は、**first boot には不要**。最小 config が要求する inline asm は空＋operand 付きバリアのみで、任意制約 inline asm はドライバや広い config の段階（L3b）に後退する。これが最大の de-risking。
+x86mov32 ではこれが [`X86-DELTA.md`](./X86-DELTA.md) の M セット = **PV-MMIO mov 列**として `arch/x86mov32` に手書きできる（trap vector→PV-CPU `IDT_BASE`、MMU→PV-MMU `PGDIR`、退避/復帰→trap frame への mov / PV `IRET`）。新たな irreducible 特権命令は増えない。
 
-## 最後に残る真の難所：entry/特権パス（= PV 境界、link/boot 必須）
+## 残リスク
 
-kill-test のサブセット外だが本質的、かつ **設計注ではなく link/boot の必須要件**（codex 強調）: riscv は `head.o`/`entry.o` を無条件ビルドし（`arch/riscv/kernel/Makefile:49-54`）、`head.S:_start`（`head.S:20-37`）・`entry.S` の trap/irq 入口（`entry.S:21-85`）が無いと **link も boot もしない**。最早期 boot/entry（trap vector 設置・MMU/`satp` 設定・context-switch のレジスタ退避）は riscv では **genuinely irreducible な手書き `.S`**。「100% mov」が実際に破れるのはここ。
-
-ただしこれは **X86-DELTA.md §4 の M クラス（特権操作）そのもの**であり、x86mov32 では **PV-MMIO mov に写像済み**：
-
-- trap vector 設置 → PV-CPU `IDT_BASE` への mov
-- MMU 設定 → PV-MMU `PGDIR` への mov
-- context-switch のレジスタ退避/復帰 → trap frame（spec §6.3）への mov 列 / PV `IRET`
-
-つまり entry stub は「特権命令」ではなく「**PV レジスタへの mov 列**」として書ける。手書きの mov 列（`arch/x86mov32` の entry）になるか、llvm-mov が PV mov を emit する形になるかは実装選択だが、**新たな irreducible 特権命令は増えない**。delta 分析と整合する。
-
-## ロードマップへの帰結
-
-- **旧 L3「任意 inline asm → mov」を分割**:
-  - **L3a（first boot 必須・小）**: 空 memory-clobber バリア + i386 varargs + i64 helper-call lowering + memcpy/memset emit。
-  - **L3b（後続・広い config / driver 用）**: 一般的な制約付き inline asm。
-- **最小 config を確定**: `SMP=n` / `PREEMPT_NONE` / nommu uaccess / `JUMP_LABEL=n` / no `RISCV_ALTERNATIVE` 相当 / no FTRACE/KPROBES / `GENERIC_ATOMIC64` / `GENERIC_LIB_*`。これを arch/x86mov32 の defconfig 起点にする。
-- **entry stub** は PV mov 列として `arch/x86mov32` に手書きできる（trap frame §6.3 / PV-CPU / PV-MMU）。
-
-## 残リスク（正直に）
-
-- 本 kill-test は arch/riscv + core の static 棚卸し。実ビルドで *他の* 必須 inline asm 形が露出する可能性は残る（L3a で逐次対応、対応不能形は早期に列挙）。
-- 空バリアと varargs は llvm-mov に **新規サブシステム**（現状ゼロ）。「小」は任意 inline asm 比であって、ゼロではない。
+- 本 kill-test は static 棚卸し。実ビルドで他の必須 inline asm 形が露出する可能性（L3a で逐次対応）。
+- 空/operand バリアと varargs は llvm-mov に新規実装（「小」は任意 inline asm 比であってゼロではない）。
 - entry stub の mov 列の正しさ（trap frame の原子的退避/復帰）は実装で詰める。
-- これは *最小 config* の話。shell/userspace/driver へ広げると inline asm 面（L3b）と atomics/SMP が再浮上する。
+- これは最小 config の話。shell/userspace/driver へ広げると inline asm（L3b）と atomics/SMP が再浮上する。

--- a/linux-mov/README.md
+++ b/linux-mov/README.md
@@ -1,0 +1,25 @@
+# linux-mov — Linux を x86mov32 へ移植する
+
+Linux カーネルを、ほぼ全てが x86 `mov`(+最小制御転送) から成る ELF32 イメージとしてビルドし、**movie86**（エミュレータ＝リファレンス実装）と**実 x86/qemu** で起動させる取り組み。
+
+中心アイデアは **x86mov32 を独立した base ISA として定義する**こと。普通の x86 は「x86mov32 + 拡張」とみなせる（RISC-V の `RV32I` + 拡張と同じモジュラ ISA 観）：
+- x86 の**計算**拡張（算術・分岐・FP）は base の `mov` 列に還元できる（llvm-mov が行う）。
+- **MMIO** は x86 と共有する機構。
+- **特権命令**だけが x86 専用で、その効果は MMIO への `mov`（PV-MMIO）で再表現する。
+
+これにより Linux 移植は arch/x86 の流用ではなく、`arch/riscv`(rv32) を手本にした **新アーキ `arch/x86mov32`** の追加になる。
+
+## 状態
+
+設計フェーズ（実装前）。feasibility kill-test は **SURVIVES**。tracking issue: #87。
+
+## ドキュメント
+
+| 文書 | 内容 |
+|---|---|
+| [`X86MOV32-SPEC.md`](./X86MOV32-SPEC.md) | **正典の機械仕様**。ISA・メモリ・fault・trap frame・PV-MMIO・プロファイル・boot |
+| [`X86-DELTA.md`](./X86-DELTA.md) | x86 との本質的差分の分析。「mov で本当にできないこと」＝ PV が供給すべきもの |
+| [`DESIGN.md`](./DESIGN.md) | Linux 移植ロードマップ（L0–L8）と、実 x86 起動のための substrate |
+| [`L0.5-KILLTEST.md`](./L0.5-KILLTEST.md) | 実 Linux に対する実現可能性調査の結果（判定 SURVIVES）|
+
+初めて読むなら SPEC → DELTA → DESIGN → KILLTEST の順。

--- a/linux-mov/X86-DELTA.md
+++ b/linux-mov/X86-DELTA.md
@@ -1,120 +1,80 @@
-# x86mov32 と x86 の本質的差分 — 特権命令の要否分析
+# x86mov32 と x86 の本質的差分
 
-> 状態: 分析ドラフト。[`X86MOV32-SPEC.md`](./X86MOV32-SPEC.md) §1(b) を裏付ける。PV surface（どの特権操作を MMIO mov に写像すべきか）の必要十分性を、原理から詰める。
-
-## 0. 問い
-
-「特権命令を使わないと**本質的に** x86 で実現できないことは何か」。それが x86mov32 が機械側（PV）で供給すべき差分であり、x86-host 実行層が実特権命令で shim すべき範囲。
+> 特権命令を使わないと本当に実現できないことは何か。それが x86mov32 が機械側（PV-MMIO）で供給すべき差分であり、実 x86 substrate が実特権命令で埋める範囲。[`X86MOV32-SPEC.md`](./X86MOV32-SPEC.md) §1(b) の裏付け。
 
 ## 1. 原理：mov はチューリング完全 → 「計算」は差分ではない
 
-mov はチューリング完全。**閉じた計算（入出力を伴わない任意の変換）は全て mov 列で書ける**。ゆえに差分は「計算能力」ではない。差分が生じうるのは次の3つの境界だけ：
+mov はチューリング完全で、入出力を伴わない任意の変換は mov 列で書ける。差分が生じるのは3つの境界だけ：
 
-1. **外界の観測**（デバイス状態・タイマ・入力を読む）
-2. **外界への作用**（コンソール出力・デバイス制御）
-3. **外界との非同期**（プログラムの都合と無関係な時刻に起きる事象）
+1. **外界の観測**（デバイス状態・タイマ・入力）
+2. **外界への作用**（コンソール・デバイス制御）
+3. **外界との非同期**（プログラムと無関係な時刻に起きる事象）
 
-(1)(2) のうち **デバイスの制御レジスタ I/O は MMIO への mov**で表現でき、x86 と機構を共有する（spec §1b）→ 特権命令は要らない。
+(1)(2) のうちデバイスの制御レジスタ I/O は **MMIO への mov** で表現でき、x86 と機構を共有する → 特権命令は要らない。残る差分の候補は (3)、「機械がプログラムに対して行う保護・変換」、そして外部エージェントの latch / DMA に絞られる。
 
-ただし2つ留保がある（round-3 指摘）：
+## 2. 分類
 
-- **外部事象は「pollable な状態に latch されている」場合に限り poll で観測できる**。タイマ tick・IRQ edge・パケット到着などを mov で読めるのは、デバイス/割り込みコントローラがそれを MMIO 可視の状態に**ラッチする外部エージェントがいるから**。この latch 自体はプログラム外の機械機能であり、特権命令の差分ではないが**指定すべきプラットフォーム意味論**（§2 の A クラス）。
-- **DMA / bus master は「I/O = MMIO mov」では覆えない**。DMA デバイスは命令列の外で非同期にメモリを読み書きする**非同期メモリエージェント**。pv-min/pv-kernel v0.2 は実 DMA デバイスを持たない（PV-CONSOLE/TIMER は DMA しない）ので回避できるが、将来のデバイスは「MMIO 制御プレーン + 非同期メモリエージェント + コヒーレンシ規約」が要る。
+各 x86 機構を次で分類する：
 
-よって本質的差分の候補は (3)・「機械がプログラムに対して行う保護・変換」・「外部エージェントの latch/DMA」に絞られる。
+- **E** — x86mov32 が概念ごと持たない（差分ですらない）
+- **R-instr** — mov 計装で原理的に実現可能だが高コスト or 非協調コードを扱えない（数学的には特権不要）
+- **R-mmio** — 共有 MMIO mov + ポーリングで実現（x86 と共有、特権不要）
+- **A** — 命令列の外で非同期に状態を latch/変更する外部エージェント（タイマ latch・IRQ pending・DMA・host clock）。pollable MMIO として露出されない限り閉じた mov 計算に還元できない
+- **M** — ポーリング/計装で代替できず、機械がプログラムに強制介入する必要がある（真の差分の核）
 
-## 2. 分類軸
-
-各 x86 特権/システム機構を次で分類する：
-
-- **E (eliminated)**: x86mov32 は概念ごと持たない。差分ですらない。
-- **R-instr (reducible by instrumentation)**: mov 計装で原理的に実現可能だが高コスト or 非協調コードを扱えない。**数学的には特権不要**。実用上 PV で提供する設計選択。
-- **R-mmio (reducible to shared MMIO + poll)**: 共有 MMIO mov + ポーリングで実現。x86 と機構共有、特権命令不要。
-- **A (external-agent)**: 命令列の外で非同期に状態を latch/変更する外部エージェント（タイマ latch・IRQ pending latch・DMA writer・host wall clock）。特権命令ではなく、強制制御転送でもないが、**pollable MMIO 状態として露出されない限り閉じた mov 計算に還元できない**プラットフォーム機能（round-3 で追加）。
-- **M (genuinely machine-driven)**: ポーリングや計装で代替**できない**。機械がプログラムに*強制的に*介入する必要がある。← **真の差分の核**。
-
-## 3. 命令・機構ごとの分類
-
-| x86 機構 | 分類 | 根拠 / x86mov32 での扱い |
+| x86 機構 | 分類 | 扱い |
 |---|---|---|
-| segmentation（`lgdt`,`mov sreg`, far jmp の seg 切替） | **E** | x86mov32 は flat のみ。概念を持たない。 |
-| ポート I/O（`in`/`out`） | **E→R-mmio** | デバイスを MMIO に置く。共有 MMIO で代替。特権不要。 |
-| 多くの MSR（`wrmsr` APIC base / syscall MSR 等）, `cpuid` | **E** | 設定対象の機能（APIC, `syscall`命令, セグメント）を使わないので不要。 |
-| `rdtsc` / タイマ読み | **R-mmio** | PV-TIMER `TICKS` の MMIO read。x86 と共有可。 |
-| `syscall`/`sysenter`/`int` による user→kernel 遷移 | **M（保護ありの場合）/ R（保護なしなら単なる call）** | 保護を敷くなら特権遷移が必要（§5 参照）。保護を敷かない初期段階では `call` で足りる。 |
-| アドレス変換 / paging（`mov CR3`,`CR0.PG`,`invlpg`, TLB） | **R-instr（原理）/ M（実用）** | 全 load/store をソフトページウォーク（mov）に計装すれば**原理的には特権不要**。だが (a) 莫大なコスト、(b) Linux は HW paging 前提。よって設計選択として PV-MMU（機械側変換）にする。 |
-| 保護 / 特権分離（ring, page U/S, SMEP/SMAP, limit 違反 #GP） | **R-instr（原理）/ M（実用）** | SFI 的に全アクセスを境界チェック計装すれば**原理的には可能**。だが非協調（未計装）コードを隔離できず、コストも高い。実用上は PV-MMU の保護ビット + fault（機械が**禁止**する）。 |
-| `iret`（EIP/SP の原子的復帰 + 特権遷移） | **M（保護/割り込みありなら）** | trap frame からの復帰自体は mov で書けるが、特権遷移と「割り込み窓を閉じたままの原子的再開」は機械機能。PV `IRET`。 |
-| 割り込み禁止/許可（`cli`/`sti`, IF） | **M（の補助）** | 後述 §4 の async 制御の窓制御。PV `INTR_MASK`。 |
-| 外部事象の latch（タイマ tick・IRQ pending を MMIO 可視状態に記録） | **A** | poll で読めるのは外部エージェントが latch するから。プラットフォーム意味論として指定要（§2 A）。 |
-| **強制的な非同期制御転送**（latch された事象で命令列を*強制的に*奪う = preemption） | **M** | ← §4。協調コードは safepoint で近似可、未計装/低遅延は irreducible。 |
-| DMA / bus master | **A** | 命令列外の非同期メモリエージェント。「I/O=MMIO mov」では覆えない。pv v0.2 は実 DMA 無しで回避、将来はコヒーレンシ規約要。 |
-| atomic RMW（`lock`,`cmpxchg`） | **R（UP）/ M（SMP）** | UP では「割り込みを閉じた非分割 mov 列」で原子性が出る（INTR_MASK 依存）。**特権不要**。SMP のバスロックは M だが SMP は非ゴール。 |
-| 自己書き換え/テキストパッチ | **R-instr / M(小)** | x86 の icache は coherent なので「icache 同期」は本質でない。本質は**改変の原子性・quiescence**（部分パッチ実行を避ける、serialize / stop-machine）。PV-TEXTPATCH = host 承認のパッチプロトコル。 |
-| `hlt`（割り込みまで idle） | **R-mmio（busy poll）/ M(任意)** | busy-loop で代替可。真の idle/省電力だけ機械機能。任意。 |
-| cache 制御（`wbinvd`,MTRR,PAT,`clflush`） | **E/host** | リファレンス機械（movie86）はキャッシュ無しで no-op。x86-host が MMIO を UC 化する shim 内事項。 |
-| メモリ順序/fence | **E(UP) / 後日** | UP/no-SMP では大半が消える。MMIO は UC・program order（spec §5）。DMA/SMP 導入時に本格的なメモリモデルが要る。 |
-| TLB shootdown（クロス CPU） | **M(SMP)** | UP は local `FLUSH` で足りる（PV-MMU）。SMP の shootdown は非同期クロス CPU 機構（非ゴール）。 |
+| segmentation（`lgdt`/`mov sreg`/far jmp）| E | flat のみ。概念を持たない |
+| ポート I/O（`in`/`out`）| E→R-mmio | デバイスを MMIO に。共有機構で代替 |
+| 多くの MSR / `cpuid` | E | 設定対象の機能（APIC・syscall命令・seg）を使わない |
+| `rdtsc` / タイマ読み | R-mmio | PV-TIMER `TICKS` の MMIO read |
+| user→kernel 遷移（`syscall`/`int`）| M（保護あり）/ R（保護なしは call）| 保護を敷くなら特権遷移、初期段階は call |
+| アドレス変換 / paging（`mov CR3`/`invlpg`/TLB）| R-instr / M(実用) | ソフトページウォークで原理可だが高コスト → PV-MMU に |
+| 保護 / 特権分離（ring・page U/S・limit）| R-instr / M(実用) | SFI 計装で原理可だが非協調コードを隔離できない → PV-MMU 保護ビット + fault |
+| `iret`（原子的復帰 + 特権遷移）| M | trap frame からの復帰自体は mov、原子性は機械機能 → PV `IRET` |
+| 割り込み禁止/許可（`cli`/`sti`）| M(補助) | 介入窓制御 → PV `INTR_MASK` |
+| **強制的な非同期制御転送**（latch 事象で命令列を奪う = preemption）| **M** | §3。協調コードは safepoint で近似可、未計装/低遅延は irreducible |
+| 外部事象の latch（タイマ/IRQ pending を MMIO 可視に）| A | poll の前提となる外部記録 |
+| DMA / bus master | A | 命令列外の非同期メモリエージェント。pv v0.2 は実 DMA 無しで回避 |
+| atomic RMW（`lock`/`cmpxchg`）| R(UP) / M(SMP) | UP は「割り込みを閉じた非分割 mov 列」で原子性（特権不要）。SMP は非ゴール |
+| 自己書き換え / テキストパッチ | R-instr / M(小) | x86 の icache は coherent。本質は改変の原子性/quiescence → PV-TEXTPATCH |
+| `hlt`（idle）| R-mmio(busy poll) / M(任意) | busy-loop で代替可。真の idle だけ機械機能 |
 
-## 4. 蒸留：irreducible なのは「native/非協調/低遅延な実行への強制介入」
+## 3. 蒸留：irreducible なのは「native/非協調/低遅延な実行への強制介入」
 
-round-3 補正。「非同期制御転送が *唯一の数学的* M」は**言い過ぎ**だった。正しくは：
+完全に計装された協調コードなら、MMU・保護・preemption・イベント配送はすべて mov 計装 + MMIO ポーリングで原理的にモデル化できる（safepoint を全 back-edge に挿せば preemption を有界遅延で近似できる）。
 
-> **完全に計装された協調コード**なら、MMU・保護・preemption・イベント配送はすべて mov 計装 + MMIO ポーリングで*原理的に*モデル化できる（safepoint を全 back-edge/呼び出し境界に挿せば timer preemption を有界遅延で近似でき、basic block を細分すればさらに詰まる）。
-> ゆえに真に irreducible な機械サービスは、**native ないし非協調なコードへの、計装密度に依存しない低遅延な強制介入**である：(i) preemption、(ii) *未計装*コードに対する保護強制、(iii) 精密な restartable trap。これに (iv) 外部エージェントの latch（§2 A クラス）が加わる。
+ゆえに真に irreducible な機械サービスは、**native ないし非協調なコードへの、計装密度に依存しない低遅延な強制介入** — (i) preemption、(ii) 未計装コードへの保護強制、(iii) 精密な restartable trap、(iv) 外部エージェントの latch（A）。
 
-- **協調コードに対する preemption は safepoint で近似可能**（有界遅延）。irreducible なのは「自分で yield を選べない/未計装のコードを止める」「計装密度と独立な低遅延・リアルタイム保証を出す」場合のみ。
-- 付随して `INTR_MASK`（介入窓）と `IRET`（原子的再開）が要る。
+MMU・保護は原理的に reducible（ソフトページング/SFI）だが、コストと非協調コード隔離のため設計選択として機械機能（PV-MMU）にする — *必要*だからではなく*実用的だから*、と正直に位置づける。
 
-MMU・保護は **原理的に reducible**（ソフトページング/SFI 計装）だが、(a) 莫大なコスト、(b) *未計装/非協調*コードを隔離できない、ため **設計選択**として機械機能（PV-MMU）にする — *必要*だからではなく*実用的かつ非協調コードを扱うため*、と正直に位置づける。
+## 4. worked example：「特権パスが mov 列」とは
 
-## 4.5 worked example：「特権パスが mov 列」とは
-
-特権操作は RISC-V/x86 では**専用オペコード**（`csrw stvec`/`csrw satp`/`sret`、`lidt`/`mov CR3`/`iret`）で、C でも普通の load/store でも書けない。x86mov32 はこれを **MMIO レジスタへの store に定義し直す**（§1b）。entry/boot を並べると：
+特権操作は RISC-V/x86 では専用オペコード（`csrw stvec` / `mov CR3` / `iret`）で、C でも普通の load/store でも書けない。x86mov32 はこれを MMIO レジスタへの store に定義し直す。
 
 ```
-; RISC-V (専用命令, 手書き .S)        ; x86mov32 (全て mov)
-csrw  stvec, trap_handler             mov [PV_CPU + IDT_BASE],  trap_handler
-csrw  satp,  (MODE|pgdir>>12)         mov [PV_MMU + PGDIR],     pgdir_phys
-csrsi sstatus, SIE                    mov [PV_CPU + INTR_MASK], 0
-sret                                  mov [PV_CPU + IRET],      0
+; RISC-V (専用命令, 手書き .S)     ; x86mov32 (全て mov)
+csrw  stvec, trap_handler          mov [PV_CPU + IDT_BASE],  trap_handler
+csrw  satp,  (MODE|pgdir>>12)      mov [PV_MMU + PGDIR],     pgdir_phys
+csrsi sstatus, SIE                 mov [PV_CPU + INTR_MASK], 0
+sret                               mov [PV_CPU + IRET],      0
 ```
 
-`csrw stvec, h`（専用命令）が `mov [magic], h`（ただのストア）になる。**機械**がそのアドレスへの mov を傍受して効果を実行する：
+`csrw stvec, h`（専用命令）が `mov [magic], h`（ただのストア）になり、機械がそれを傍受して効果を実行する。movie86 はマジックアドレス機構で内部状態を操作（guest は 100% mov）；実 x86 substrate は PV ページを not-present にして mov→#PF→本物の `lidt`/`mov CR3` を実行（特権命令は substrate に隔離）。文脈切替のレジスタ退避/復帰は元から mov+push/pop。
 
-- movie86: magic-address 機構（既存 `0x1FFE_0000`→AbiHost）の拡張で内部状態を操作 → guest は文字通り 100% mov。
-- 実 x86 host: PV ページを not-present にし、mov→#PF→substrate(非-mov ring0)が faulting mov をデコードして本物の `lidt`/`mov CR3` を実行。**特権命令は substrate に隔離、カーネルは純 mov**。
+**境界**: カーネルが能動的に*やる*ことは全て mov（特権効果の要求すら PV store）。mov でないのは命令ですらない2つの機械機能 — trap の*配送*（M）と `IRET` の*原子的*復帰。**カーネルの命令ストリームは 100% mov、非-mov な部分は「機械そのもの」**。
 
-文脈切替のレジスタ退避/復帰は元から mov+push/pop（特権ですらない）；特権なのはアドレス空間切替=PV-MMU `PGDIR` への mov だけ。
-
-**境界**: カーネルが能動的に*やる*ことは全て mov（特権効果の要求すら PV store）。mov でないのは命令ですらない2つの機械機能 — (1) trap の*配送*（§4 の M, 機械が命令列を奪い frame を積む）、(2) `IRET` の*原子的*復帰（カーネルは mov で要求、復元は機械）。**カーネルの命令ストリームは 100% mov、非-mov な部分は「機械そのもの」**。
-
-## 5. PV surface への帰結（必要十分）
+## 5. PV surface への帰結
 
 | 真の性質 | PV | 理由 |
 |---|---|---|
-| 強制的な非同期制御転送（M, 核） | PV-IRQ + 強制ジャンプ配送 + `INTR_MASK` + `IRET` | native/未計装/低遅延では poll 代替不能 |
-| 外部事象の latch（A） | PV-TIMER/PV-IRQ の pending 状態 | poll の前提となる外部記録 |
-| アドレス変換（実用的 M, 原理 R-instr） | PV-MMU `PGDIR`/`FLUSH`/`FAULT_ADDR` | HW paging 前提 + コスト |
-| 保護/特権分離（実用的 M, 原理 R-instr） | PV-MMU 保護ビット + fault + `IDT_BASE` | 非協調コード隔離 + コスト |
-| 外界 device I/O（R-mmio, **x86 と共有**） | PV-CONSOLE / PV-TIMER（+任意デバイス） | 特権不要、shim ほぼ無し。ただし DMA は別（A, v0.2 外） |
-| テキストパッチの原子性/quiescence（小 M） | PV-TEXTPATCH or config-off | 部分パッチ実行回避 |
+| 強制的な非同期制御転送（M, 核）| PV-IRQ + 強制ジャンプ + `INTR_MASK` + `IRET` | native/未計装/低遅延では poll 代替不能 |
+| 外部事象の latch（A）| PV-TIMER/PV-IRQ の pending | poll の前提 |
+| アドレス変換（実用 M, 原理 R）| PV-MMU `PGDIR`/`FLUSH`/`FAULT_ADDR` | HW paging 前提 + コスト |
+| 保護/特権分離（実用 M, 原理 R）| PV-MMU 保護ビット + fault + `IDT_BASE` | 非協調コード隔離 |
+| 外界 device I/O（R-mmio, x86 と共有）| PV-CONSOLE / PV-TIMER | 特権不要。DMA は別（A, v0.2 外）|
+| テキストパッチの原子性（小 M）| PV-TEXTPATCH or config-off | 部分パッチ実行回避 |
 
-→ spec §7 の PV-* は **ここで識別した差分を覆う**（pv-min 面は確定的、**pv-kernel 面（PV-CPU/IRQ/MMU）は draft で未閉** — 例: TRAP_STACK の nested trap 意味論は L2 で確定）。**特に「外界 device I/O は特権差分ではなく共有」**である点が重要（x86-host shim が要るのは MMU/protection/preempt/textpatch の機械機能 + 外部 latch だけ）。DMA を持つ実デバイスは v0.2 のスコープ外（A クラスのメモリモデルが要る）。
+spec §7 の PV-* はこの差分を覆う（pv-min は確定、pv-kernel 面は draft）。**外界 device I/O は特権差分ではなく x86 と共有**である点が重要。
 
-**閉包（round-4 補正: 等号でなく包含）**: カーネルの PV M-set（`lgdt`/`lidt`/`mov CRn`/`sti`/`cli`/`iret`/`invlpg` 相当）は、x86-host substrate を mov 化したときに残る非-mov 核の **部分集合**。substrate の非-mov 集合は **真の上位集合**であり、host 固有の義務が加わる：
-
-- **PV M-set**（カーネルが PV-MMIO で要求する特権効果を実命令で実装）
-- **+ substrate-only**: real-mode→protected-mode boot（A20/`lgdt`/`mov CR0`/far jump）、#PF cause 読み（`mov from CR2` — カーネルは PV `FAULT_ADDR` を読むが substrate は CR2）、実 IRQ コントローラ操作（PIC=port I/O / APIC=MMIO+MSR）と EOI、whitelist/実行権限の強制フック。
-
-つまり **カーネル PV M-set ⊂ substrate irreducible set**。movie86 ではこの全体を Rust で実装、実 x86 substrate では実特権命令の最小スタブ群として実装する。x86mov32 がカーネルから追い出した特権はここで最小化されて再出現する — ゼロにはできないが、周辺は全て mov 化できる。
-
-## 6. L0.5 で実 Linux / arch/riscv と突き合わせる検証
-
-本分析は原理側。実装側の致命要因は別途 kill-test で確認する：
-
-- Linux UP で atomics を本当に「割り込みマスク + 非分割列」に落とせるか（`atomic_t`,`cmpxchg`, `local_irq_save` の使われ方）。
-- preemption を safepoint 近似に落とせるか、それとも真の timer 割り込み（強制ジャンプ M）が必須か（`CONFIG_PREEMPT*`, cond_resched, スケジューラ）。
-- demand paging / `copy_*_user` fixup が PV-MMU + fault 配送で閉じるか。
-- テキストパッチ経路（alternatives/static-keys/ftrace/kprobes/paravirt）を対象 config で無効化できるか、PV-TEXTPATCH が要るか。
-- arch/riscv が上記をどう解いているか（SBI/CLINT/PLIC/sfence）を直接の移植参照点にする。
+**閉包（substrate との関係）**: カーネルの PV M-set（`lidt`/`mov CRn`/`sti`/`iret`/`invlpg` 相当）は、substrate を mov 化したときの非-mov 核の**部分集合**。substrate の非-mov 集合はその**上位集合**で、host 固有義務（real-mode boot・`mov from CR2`・実 IRQ コントローラ+EOI・whitelist 強制）が加わる。movie86 はこの全体を Rust で、実 x86 substrate は実特権命令の最小スタブ群で実装する。x86mov32 がカーネルから追い出した特権は、ここで最小化されて再出現する — ゼロにはできないが、周辺は全て mov 化できる。

--- a/linux-mov/X86-DELTA.md
+++ b/linux-mov/X86-DELTA.md
@@ -102,6 +102,8 @@ sret                                  mov [PV_CPU + IRET],      0
 
 → spec §7 の PV-* は過不足ない。**特に「外界 device I/O は特権差分ではなく共有」**である点が重要（x86-host shim が要るのは MMU/protection/preempt/textpatch の機械機能 + 外部 latch だけ）。DMA を持つ実デバイスは v0.2 のスコープ外（A クラスのメモリモデルが要る）。
 
+**閉包**: この M セット（`lgdt`/`lidt`/`mov CRn`/`sti`/`cli`/`iret`/`invlpg` + boot stub）は、x86-host substrate を mov 化したときに **irreducible に非-mov として残る核**そのもの（DESIGN §3.5）。movie86 ではこの核を Rust で実装し、実 x86 substrate では実特権命令の最小スタブとして実装する。x86mov32 がカーネルから追い出した特権は、ここで最小化されて再出現する — ゼロにはできないが、周辺は全て mov 化できる。
+
 ## 6. L0.5 で実 Linux / arch/riscv と突き合わせる検証
 
 本分析は原理側。実装側の致命要因は別途 kill-test で確認する：

--- a/linux-mov/X86-DELTA.md
+++ b/linux-mov/X86-DELTA.md
@@ -68,6 +68,27 @@ round-3 補正。「非同期制御転送が *唯一の数学的* M」は**言�
 
 MMU・保護は **原理的に reducible**（ソフトページング/SFI 計装）だが、(a) 莫大なコスト、(b) *未計装/非協調*コードを隔離できない、ため **設計選択**として機械機能（PV-MMU）にする — *必要*だからではなく*実用的かつ非協調コードを扱うため*、と正直に位置づける。
 
+## 4.5 worked example：「特権パスが mov 列」とは
+
+特権操作は RISC-V/x86 では**専用オペコード**（`csrw stvec`/`csrw satp`/`sret`、`lidt`/`mov CR3`/`iret`）で、C でも普通の load/store でも書けない。x86mov32 はこれを **MMIO レジスタへの store に定義し直す**（§1b）。entry/boot を並べると：
+
+```
+; RISC-V (専用命令, 手書き .S)        ; x86mov32 (全て mov)
+csrw  stvec, trap_handler             mov [PV_CPU + IDT_BASE],  trap_handler
+csrw  satp,  (MODE|pgdir>>12)         mov [PV_MMU + PGDIR],     pgdir_phys
+csrsi sstatus, SIE                    mov [PV_CPU + INTR_MASK], 0
+sret                                  mov [PV_CPU + IRET],      0
+```
+
+`csrw stvec, h`（専用命令）が `mov [magic], h`（ただのストア）になる。**機械**がそのアドレスへの mov を傍受して効果を実行する：
+
+- movie86: magic-address 機構（既存 `0x1FFE_0000`→AbiHost）の拡張で内部状態を操作 → guest は文字通り 100% mov。
+- 実 x86 host: PV ページを not-present にし、mov→#PF→substrate(非-mov ring0)が faulting mov をデコードして本物の `lidt`/`mov CR3` を実行。**特権命令は substrate に隔離、カーネルは純 mov**。
+
+文脈切替のレジスタ退避/復帰は元から mov+push/pop（特権ですらない）；特権なのはアドレス空間切替=PV-MMU `PGDIR` への mov だけ。
+
+**境界**: カーネルが能動的に*やる*ことは全て mov（特権効果の要求すら PV store）。mov でないのは命令ですらない2つの機械機能 — (1) trap の*配送*（§4 の M, 機械が命令列を奪い frame を積む）、(2) `IRET` の*原子的*復帰（カーネルは mov で要求、復元は機械）。**カーネルの命令ストリームは 100% mov、非-mov な部分は「機械そのもの」**。
+
 ## 5. PV surface への帰結（必要十分）
 
 | 真の性質 | PV | 理由 |

--- a/linux-mov/X86-DELTA.md
+++ b/linux-mov/X86-DELTA.md
@@ -100,7 +100,7 @@ sret                                  mov [PV_CPU + IRET],      0
 | 外界 device I/O（R-mmio, **x86 と共有**） | PV-CONSOLE / PV-TIMER（+任意デバイス） | 特権不要、shim ほぼ無し。ただし DMA は別（A, v0.2 外） |
 | テキストパッチの原子性/quiescence（小 M） | PV-TEXTPATCH or config-off | 部分パッチ実行回避 |
 
-→ spec §7 の PV-* は過不足ない。**特に「外界 device I/O は特権差分ではなく共有」**である点が重要（x86-host shim が要るのは MMU/protection/preempt/textpatch の機械機能 + 外部 latch だけ）。DMA を持つ実デバイスは v0.2 のスコープ外（A クラスのメモリモデルが要る）。
+→ spec §7 の PV-* は **ここで識別した差分を覆う**（pv-min 面は確定的、**pv-kernel 面（PV-CPU/IRQ/MMU）は draft で未閉** — 例: TRAP_STACK の nested trap 意味論は L2 で確定）。**特に「外界 device I/O は特権差分ではなく共有」**である点が重要（x86-host shim が要るのは MMU/protection/preempt/textpatch の機械機能 + 外部 latch だけ）。DMA を持つ実デバイスは v0.2 のスコープ外（A クラスのメモリモデルが要る）。
 
 **閉包（round-4 補正: 等号でなく包含）**: カーネルの PV M-set（`lgdt`/`lidt`/`mov CRn`/`sti`/`cli`/`iret`/`invlpg` 相当）は、x86-host substrate を mov 化したときに残る非-mov 核の **部分集合**。substrate の非-mov 集合は **真の上位集合**であり、host 固有の義務が加わる：
 

--- a/linux-mov/X86-DELTA.md
+++ b/linux-mov/X86-DELTA.md
@@ -102,7 +102,12 @@ sret                                  mov [PV_CPU + IRET],      0
 
 → spec §7 の PV-* は過不足ない。**特に「外界 device I/O は特権差分ではなく共有」**である点が重要（x86-host shim が要るのは MMU/protection/preempt/textpatch の機械機能 + 外部 latch だけ）。DMA を持つ実デバイスは v0.2 のスコープ外（A クラスのメモリモデルが要る）。
 
-**閉包**: この M セット（`lgdt`/`lidt`/`mov CRn`/`sti`/`cli`/`iret`/`invlpg` + boot stub）は、x86-host substrate を mov 化したときに **irreducible に非-mov として残る核**そのもの（DESIGN §3.5）。movie86 ではこの核を Rust で実装し、実 x86 substrate では実特権命令の最小スタブとして実装する。x86mov32 がカーネルから追い出した特権は、ここで最小化されて再出現する — ゼロにはできないが、周辺は全て mov 化できる。
+**閉包（round-4 補正: 等号でなく包含）**: カーネルの PV M-set（`lgdt`/`lidt`/`mov CRn`/`sti`/`cli`/`iret`/`invlpg` 相当）は、x86-host substrate を mov 化したときに残る非-mov 核の **部分集合**。substrate の非-mov 集合は **真の上位集合**であり、host 固有の義務が加わる：
+
+- **PV M-set**（カーネルが PV-MMIO で要求する特権効果を実命令で実装）
+- **+ substrate-only**: real-mode→protected-mode boot（A20/`lgdt`/`mov CR0`/far jump）、#PF cause 読み（`mov from CR2` — カーネルは PV `FAULT_ADDR` を読むが substrate は CR2）、実 IRQ コントローラ操作（PIC=port I/O / APIC=MMIO+MSR）と EOI、whitelist/実行権限の強制フック。
+
+つまり **カーネル PV M-set ⊂ substrate irreducible set**。movie86 ではこの全体を Rust で実装、実 x86 substrate では実特権命令の最小スタブ群として実装する。x86mov32 がカーネルから追い出した特権はここで最小化されて再出現する — ゼロにはできないが、周辺は全て mov 化できる。
 
 ## 6. L0.5 で実 Linux / arch/riscv と突き合わせる検証
 

--- a/linux-mov/X86-DELTA.md
+++ b/linux-mov/X86-DELTA.md
@@ -1,0 +1,92 @@
+# x86mov32 と x86 の本質的差分 — 特権命令の要否分析
+
+> 状態: 分析ドラフト。[`X86MOV32-SPEC.md`](./X86MOV32-SPEC.md) §1(b) を裏付ける。PV surface（どの特権操作を MMIO mov に写像すべきか）の必要十分性を、原理から詰める。
+
+## 0. 問い
+
+「特権命令を使わないと**本質的に** x86 で実現できないことは何か」。それが x86mov32 が機械側（PV）で供給すべき差分であり、x86-host 実行層が実特権命令で shim すべき範囲。
+
+## 1. 原理：mov はチューリング完全 → 「計算」は差分ではない
+
+mov はチューリング完全。**閉じた計算（入出力を伴わない任意の変換）は全て mov 列で書ける**。ゆえに差分は「計算能力」ではない。差分が生じうるのは次の3つの境界だけ：
+
+1. **外界の観測**（デバイス状態・タイマ・入力を読む）
+2. **外界への作用**（コンソール出力・デバイス制御）
+3. **外界との非同期**（プログラムの都合と無関係な時刻に起きる事象）
+
+(1)(2) のうち **デバイスの制御レジスタ I/O は MMIO への mov**で表現でき、x86 と機構を共有する（spec §1b）→ 特権命令は要らない。
+
+ただし2つ留保がある（round-3 指摘）：
+
+- **外部事象は「pollable な状態に latch されている」場合に限り poll で観測できる**。タイマ tick・IRQ edge・パケット到着などを mov で読めるのは、デバイス/割り込みコントローラがそれを MMIO 可視の状態に**ラッチする外部エージェントがいるから**。この latch 自体はプログラム外の機械機能であり、特権命令の差分ではないが**指定すべきプラットフォーム意味論**（§2 の A クラス）。
+- **DMA / bus master は「I/O = MMIO mov」では覆えない**。DMA デバイスは命令列の外で非同期にメモリを読み書きする**非同期メモリエージェント**。pv-min/pv-kernel v0.2 は実 DMA デバイスを持たない（PV-CONSOLE/TIMER は DMA しない）ので回避できるが、将来のデバイスは「MMIO 制御プレーン + 非同期メモリエージェント + コヒーレンシ規約」が要る。
+
+よって本質的差分の候補は (3)・「機械がプログラムに対して行う保護・変換」・「外部エージェントの latch/DMA」に絞られる。
+
+## 2. 分類軸
+
+各 x86 特権/システム機構を次で分類する：
+
+- **E (eliminated)**: x86mov32 は概念ごと持たない。差分ですらない。
+- **R-instr (reducible by instrumentation)**: mov 計装で原理的に実現可能だが高コスト or 非協調コードを扱えない。**数学的には特権不要**。実用上 PV で提供する設計選択。
+- **R-mmio (reducible to shared MMIO + poll)**: 共有 MMIO mov + ポーリングで実現。x86 と機構共有、特権命令不要。
+- **A (external-agent)**: 命令列の外で非同期に状態を latch/変更する外部エージェント（タイマ latch・IRQ pending latch・DMA writer・host wall clock）。特権命令ではなく、強制制御転送でもないが、**pollable MMIO 状態として露出されない限り閉じた mov 計算に還元できない**プラットフォーム機能（round-3 で追加）。
+- **M (genuinely machine-driven)**: ポーリングや計装で代替**できない**。機械がプログラムに*強制的に*介入する必要がある。← **真の差分の核**。
+
+## 3. 命令・機構ごとの分類
+
+| x86 機構 | 分類 | 根拠 / x86mov32 での扱い |
+|---|---|---|
+| segmentation（`lgdt`,`mov sreg`, far jmp の seg 切替） | **E** | x86mov32 は flat のみ。概念を持たない。 |
+| ポート I/O（`in`/`out`） | **E→R-mmio** | デバイスを MMIO に置く。共有 MMIO で代替。特権不要。 |
+| 多くの MSR（`wrmsr` APIC base / syscall MSR 等）, `cpuid` | **E** | 設定対象の機能（APIC, `syscall`命令, セグメント）を使わないので不要。 |
+| `rdtsc` / タイマ読み | **R-mmio** | PV-TIMER `TICKS` の MMIO read。x86 と共有可。 |
+| `syscall`/`sysenter`/`int` による user→kernel 遷移 | **M（保護ありの場合）/ R（保護なしなら単なる call）** | 保護を敷くなら特権遷移が必要（§5 参照）。保護を敷かない初期段階では `call` で足りる。 |
+| アドレス変換 / paging（`mov CR3`,`CR0.PG`,`invlpg`, TLB） | **R-instr（原理）/ M（実用）** | 全 load/store をソフトページウォーク（mov）に計装すれば**原理的には特権不要**。だが (a) 莫大なコスト、(b) Linux は HW paging 前提。よって設計選択として PV-MMU（機械側変換）にする。 |
+| 保護 / 特権分離（ring, page U/S, SMEP/SMAP, limit 違反 #GP） | **R-instr（原理）/ M（実用）** | SFI 的に全アクセスを境界チェック計装すれば**原理的には可能**。だが非協調（未計装）コードを隔離できず、コストも高い。実用上は PV-MMU の保護ビット + fault（機械が**禁止**する）。 |
+| `iret`（EIP/SP の原子的復帰 + 特権遷移） | **M（保護/割り込みありなら）** | trap frame からの復帰自体は mov で書けるが、特権遷移と「割り込み窓を閉じたままの原子的再開」は機械機能。PV `IRET`。 |
+| 割り込み禁止/許可（`cli`/`sti`, IF） | **M（の補助）** | 後述 §4 の async 制御の窓制御。PV `INTR_MASK`。 |
+| 外部事象の latch（タイマ tick・IRQ pending を MMIO 可視状態に記録） | **A** | poll で読めるのは外部エージェントが latch するから。プラットフォーム意味論として指定要（§2 A）。 |
+| **強制的な非同期制御転送**（latch された事象で命令列を*強制的に*奪う = preemption） | **M** | ← §4。協調コードは safepoint で近似可、未計装/低遅延は irreducible。 |
+| DMA / bus master | **A** | 命令列外の非同期メモリエージェント。「I/O=MMIO mov」では覆えない。pv v0.2 は実 DMA 無しで回避、将来はコヒーレンシ規約要。 |
+| atomic RMW（`lock`,`cmpxchg`） | **R（UP）/ M（SMP）** | UP では「割り込みを閉じた非分割 mov 列」で原子性が出る（INTR_MASK 依存）。**特権不要**。SMP のバスロックは M だが SMP は非ゴール。 |
+| 自己書き換え/テキストパッチ | **R-instr / M(小)** | x86 の icache は coherent なので「icache 同期」は本質でない。本質は**改変の原子性・quiescence**（部分パッチ実行を避ける、serialize / stop-machine）。PV-TEXTPATCH = host 承認のパッチプロトコル。 |
+| `hlt`（割り込みまで idle） | **R-mmio（busy poll）/ M(任意)** | busy-loop で代替可。真の idle/省電力だけ機械機能。任意。 |
+| cache 制御（`wbinvd`,MTRR,PAT,`clflush`） | **E/host** | リファレンス機械（movie86）はキャッシュ無しで no-op。x86-host が MMIO を UC 化する shim 内事項。 |
+| メモリ順序/fence | **E(UP) / 後日** | UP/no-SMP では大半が消える。MMIO は UC・program order（spec §5）。DMA/SMP 導入時に本格的なメモリモデルが要る。 |
+| TLB shootdown（クロス CPU） | **M(SMP)** | UP は local `FLUSH` で足りる（PV-MMU）。SMP の shootdown は非同期クロス CPU 機構（非ゴール）。 |
+
+## 4. 蒸留：irreducible なのは「native/非協調/低遅延な実行への強制介入」
+
+round-3 補正。「非同期制御転送が *唯一の数学的* M」は**言い過ぎ**だった。正しくは：
+
+> **完全に計装された協調コード**なら、MMU・保護・preemption・イベント配送はすべて mov 計装 + MMIO ポーリングで*原理的に*モデル化できる（safepoint を全 back-edge/呼び出し境界に挿せば timer preemption を有界遅延で近似でき、basic block を細分すればさらに詰まる）。
+> ゆえに真に irreducible な機械サービスは、**native ないし非協調なコードへの、計装密度に依存しない低遅延な強制介入**である：(i) preemption、(ii) *未計装*コードに対する保護強制、(iii) 精密な restartable trap。これに (iv) 外部エージェントの latch（§2 A クラス）が加わる。
+
+- **協調コードに対する preemption は safepoint で近似可能**（有界遅延）。irreducible なのは「自分で yield を選べない/未計装のコードを止める」「計装密度と独立な低遅延・リアルタイム保証を出す」場合のみ。
+- 付随して `INTR_MASK`（介入窓）と `IRET`（原子的再開）が要る。
+
+MMU・保護は **原理的に reducible**（ソフトページング/SFI 計装）だが、(a) 莫大なコスト、(b) *未計装/非協調*コードを隔離できない、ため **設計選択**として機械機能（PV-MMU）にする — *必要*だからではなく*実用的かつ非協調コードを扱うため*、と正直に位置づける。
+
+## 5. PV surface への帰結（必要十分）
+
+| 真の性質 | PV | 理由 |
+|---|---|---|
+| 強制的な非同期制御転送（M, 核） | PV-IRQ + 強制ジャンプ配送 + `INTR_MASK` + `IRET` | native/未計装/低遅延では poll 代替不能 |
+| 外部事象の latch（A） | PV-TIMER/PV-IRQ の pending 状態 | poll の前提となる外部記録 |
+| アドレス変換（実用的 M, 原理 R-instr） | PV-MMU `PGDIR`/`FLUSH`/`FAULT_ADDR` | HW paging 前提 + コスト |
+| 保護/特権分離（実用的 M, 原理 R-instr） | PV-MMU 保護ビット + fault + `IDT_BASE` | 非協調コード隔離 + コスト |
+| 外界 device I/O（R-mmio, **x86 と共有**） | PV-CONSOLE / PV-TIMER（+任意デバイス） | 特権不要、shim ほぼ無し。ただし DMA は別（A, v0.2 外） |
+| テキストパッチの原子性/quiescence（小 M） | PV-TEXTPATCH or config-off | 部分パッチ実行回避 |
+
+→ spec §7 の PV-* は過不足ない。**特に「外界 device I/O は特権差分ではなく共有」**である点が重要（x86-host shim が要るのは MMU/protection/preempt/textpatch の機械機能 + 外部 latch だけ）。DMA を持つ実デバイスは v0.2 のスコープ外（A クラスのメモリモデルが要る）。
+
+## 6. L0.5 で実 Linux / arch/riscv と突き合わせる検証
+
+本分析は原理側。実装側の致命要因は別途 kill-test で確認する：
+
+- Linux UP で atomics を本当に「割り込みマスク + 非分割列」に落とせるか（`atomic_t`,`cmpxchg`, `local_irq_save` の使われ方）。
+- preemption を safepoint 近似に落とせるか、それとも真の timer 割り込み（強制ジャンプ M）が必須か（`CONFIG_PREEMPT*`, cond_resched, スケジューラ）。
+- demand paging / `copy_*_user` fixup が PV-MMU + fault 配送で閉じるか。
+- テキストパッチ経路（alternatives/static-keys/ftrace/kprobes/paravirt）を対象 config で無効化できるか、PV-TEXTPATCH が要るか。
+- arch/riscv が上記をどう解いているか（SBI/CLINT/PLIC/sfence）を直接の移植参照点にする。

--- a/linux-mov/X86MOV32-SPEC.md
+++ b/linux-mov/X86MOV32-SPEC.md
@@ -65,12 +65,13 @@ movie86 は base + MMIO + PV-* を直接実装するリファレンス実装。c
 | **x86mov32-base** | §3 ISA + §4 レジスタ + §5 メモリ + §6 fault + §9 boot | 計算 + halt/exit。デバイス無し |
 | **x86mov32-pv-min** | base + §7.3 PV-CONSOLE + §7.4 PV-TIMER（割り込み無しの read） | 極小カーネルが print / tick poll |
 | **x86mov32-pv-kernel** | pv-min + §7.5 PV-CPU + §7.6 PV-IRQ + §7.7 PV-MMU + §6.3 trap 配送 | Linux/x86mov32 級（demand paging・割り込み・preemption）|
-| **x86mov32-compat-movfuscator** | base + 旧 movfuscator 互換（`int 0x80` syscall・SIGILL/SIGSEGV dispatch・segment-mov 経路）| 既存 movie86 資産（movfuscator-wasm 等）の後方互換 |
+| **x86mov32-compat-movfuscator** | base + 旧 movfuscator 互換（`int 0x80` syscall・SIGILL/SIGSEGV dispatch・segment-mov 経路）| 既存 movie86 資産の互換。**optional・best-effort**（design stance 参照） |
 
 **規則**:
 - 「X は x86mov32-pv-min を狙う」と profile 名で書く。movie86 は各 profile のリファレンス実装。
 - **x86-host 実行層**は profile ではなく「実 x86/qemu 上で指定 profile を供給する層」。同名 profile の §8 テストを通すか、通らない差分を conformance gap として文書化した場合のみ「その profile を host できる」と言える。
 - 互換ハック（§3.3）は **base に入れない**。`x86mov32-compat-movfuscator` に隔離する。
+- **design stance: movie86 の AS-IS 仕様は維持制約ではない**。movie86 を x86mov32 のリファレンス機械へ再形成する際、現行の userspace-runner 挙動・movfuscator 実行・寛容な flat メモリ・`0x1FFE_0000` ABI を保存する義務はない。`x86mov32-compat-movfuscator` は **optional な legacy モード**であって x86mov32 の設計を縛らない。既存資産（movfuscator-wasm / explorer 等）の互換は best-effort で、必要になった時だけ legacy モードとして供給する。
 
 ## 3. ISA サブセット（base, 凍結）
 

--- a/linux-mov/X86MOV32-SPEC.md
+++ b/linux-mov/X86MOV32-SPEC.md
@@ -108,7 +108,8 @@ base / pv に **観測可能な EFLAGS は存在しない**。許可命令はフ
 ## 5. メモリモデル（base, 凍結）
 
 - フラット 32bit バイトアドレス空間、リトルエンディアン。
-- **マップ規約（Codex round-2 対応）**: x86mov32 は **明示的にマップされた領域のみ**有効。base/pv-min では「PT_LOAD + BSS（§9）+ 宣言された PV-MMIO 領域（§7）」だけがマップされ、それ以外へのアクセスは fault（§6.1）。bare-metal 物理メモリモデルではない。
+- **マップ規約（Codex round-2 対応）**: x86mov32 は **明示的にマップされた領域のみ**有効。base/pv-min では「PT_LOAD + BSS（§9）+ boot stack（§9 で確保する実装定義領域）+ 宣言された PV-MMIO 領域（§7）」だけがマップされ、それ以外へのアクセスは fault（§6.1）。bare-metal 物理メモリモデルではない。
+  - **実装モデル（L0）**: movie86 は現状の flat 配列を **interval map**（マップ済み区間の集合）に置き換え、区間外を fault とする。base/pv-min L0 では **presence（マップの有無）判定で十分**で、W^X / `p_flags` の権限強制は後段（保護を導入する pv-kernel）まで不要。
 - **アラインメント**: 非整列アクセスは許可（`#AC` 相当は発生しない）。
 - **自己書き換えコード**: base では **不許可**（W^X 前提）。Linux のテストパッチ機構（alternatives / static-keys / jump-label / ftrace / kprobes / paravirt-patch）は §7.8 PV-TEXTPATCH か「対象 config で全テキスト改変を無効化」のいずれかで扱う（§10 未確定、ただし mainline 移植の必須検討事項）。
 - **MMIO は唯一の I/O 機構**（ポート I/O は持たない, §1b）。MMIO 領域（§7）アクセスは strong ordering（プログラム順, x86 の UC メモリ型相当 — この機構と順序は x86 と共有する）。UP・単一スレッド前提、投機・並べ替え無し。
@@ -147,7 +148,8 @@ offset  field
 
 - **EFLAGS は含めない**（§3.4 と整合）。x86mov32 は x86 の exception frame を模さず、自前の frame を定義する。Linux/x86mov32 の `pt_regs` 相当はこの frame に合わせて新規定義する（arch/x86mov32 側の責務）。
 - `IRET`（§7.5）はこの frame から GPR/EIP/ESP を復帰する。割り込みは resume 点まで masked のまま（原子的再開）。
-- **frame の置き場所と trap stack（round-4）**: 機械はゲストが事前に登録した **trap stack** に frame を積み、ハンドラ進入時に **ESP=その trap stack** とする。trap stack は PV-CPU `TRAP_STACK` レジスタ（§7.5）でゲストが設定する。これにより、割り込み元の ESP が不正/ユーザ空間でも既知良好スタックでハンドラが回り、ハンドラ本体は純 mov で書ける（ハンドラ prologue に非-mov なスタック確立は不要）。
+- **frame の置き場所と trap stack（round-4, 詳細は L2 で確定）**: 機械はゲストが事前に登録した **trap stack** に frame を積み、ハンドラ進入時に **ESP=その trap stack** とする。trap stack は PV-CPU `TRAP_STACK` レジスタ（§7.5）でゲストが設定する。これにより、割り込み元の ESP が不正/ユーザ空間でも既知良好スタックでハンドラが回り、ハンドラ本体は純 mov で書ける（ハンドラ prologue に非-mov なスタック確立は不要）。
+  - **未確定（draft, L2 で決める, round-5）**: `TRAP_STACK` が top-of-stack か frame base か / 機械が frame サイズ分 decrement するか / **nested trap**（trap stack 上で再 fault した場合に frame を上書きするか別領域か）/ frame 構築の前後で async IRQ を mask するタイミング。pv-min（割り込み無し）では未使用なので L0 はブロックしない。
 - **RISC-V との対応**: `saved EIP`↔`sepc`、`trap_kind`/`error_code`↔`scause`、`fault_addr`↔`stval`、`IRET`↔`sret`、`TRAP_STACK`↔`sscratch`（カーネルスタック退避）。frame レイアウトの確定はこの既知モデルを踏襲しており、arch/riscv の trap 処理が移植の参考になる。
 
 ## 7. PV-MMIO ABI
@@ -234,6 +236,8 @@ read 専用レジスタへの write、write 専用への read、未定義オフ�
 
 **pv-min 必須**: PUTC 出力 / STATUS / TICKS 単調増加 / MMIO 不正オフセット fault / DISCOVERY 各フィールド。
 
+**L0 具体 fixture（実装の最初のテストセット）**: `putc_ok`（PUTC 出力が host に届く）/ `status_read_ok` / `putc_read_fault`（W 専用を read→fault）/ `status_write_fault`（R 専用を write→fault）/ `mmio_byte_fault`（PUTC へ byte store→fault, 4byte 自然整列のみ有効）/ `mmio_unaligned_fault` / `mmio_bad_offset_fault` / `unmapped_load_fault` / `unmapped_fetch_fault` / `exit_ok`。各 fixture は tiny ELF + 期待する stdout または fault record。
+
 **pv-kernel 必須**（0.2 で枠、意味確定後に具体化）: trap frame レイアウト（§6.3）/ IRET 往復 / INTR_MASK 効果 / page fault → FAULT_ADDR / PGDIR による VA→PA。
 
 ## 9. boot / calling convention（base, 凍結）
@@ -241,7 +245,7 @@ read 専用レジスタへの write、write 専用への read、未定義オフ�
 - ELF32 LE i386, `ET_EXEC`, 静的リンク。`PT_INTERP`/`PT_DYNAMIC` 不可。
 - 初期 EIP = `e_entry`。memory は PT_LOAD + BSS をゼロ初期化。これらと PV-MMIO 領域のみがマップされる（§5）。
 - **2 種類の boot 契約**（凍結）:
-  - **program boot**（base / pv-min）: 初期スタック = SysV ABI 最小像（argc=0, argv/envp/auxv=NULL）、ESP は argc を指す。極小プログラム・L1 極小カーネル用。
+  - **program boot**（base / pv-min）: 初期スタック = SysV ABI 最小像（argc=0, argv/envp/auxv=NULL）、ESP は argc を指す。極小プログラム・L1 極小カーネル用。**boot stack は実装定義の固定領域**（base/top と extent を実装が決め、§5 のマップ集合に含める）。L0 テストの決定性のため、この領域の base/サイズを実装で固定する。
   - **kernel boot**（pv-kernel）: エントリで **DTB 物理アドレスを `EBX` に**、boot magic を `EAX` に渡す（RISC-V の `a0=hartid, a1=dtb` に相当する規約を x86mov32 用に固定）。カーネルは DTB からハードウェアを discover する（§7.10）。今この規約を固定し、将来の破壊的変更を避ける。
 - 終了 = halt、または compat profile の legacy exit。
 

--- a/linux-mov/X86MOV32-SPEC.md
+++ b/linux-mov/X86MOV32-SPEC.md
@@ -146,8 +146,9 @@ offset  field
 ```
 
 - **EFLAGS は含めない**（§3.4 と整合）。x86mov32 は x86 の exception frame を模さず、自前の frame を定義する。Linux/x86mov32 の `pt_regs` 相当はこの frame に合わせて新規定義する（arch/x86mov32 側の責務）。
-- `IRET`（§7.5）はこの frame から GPR/EIP/ESP を復帰する。
-- **RISC-V との対応**: `saved EIP`↔`sepc`、`trap_kind`/`error_code`↔`scause`、`fault_addr`↔`stval`、`IRET`↔`sret`。frame レイアウトの確定はこの既知モデルを踏襲しており、arch/riscv の trap 処理が移植の参考になる。
+- `IRET`（§7.5）はこの frame から GPR/EIP/ESP を復帰する。割り込みは resume 点まで masked のまま（原子的再開）。
+- **frame の置き場所と trap stack（round-4）**: 機械はゲストが事前に登録した **trap stack** に frame を積み、ハンドラ進入時に **ESP=その trap stack** とする。trap stack は PV-CPU `TRAP_STACK` レジスタ（§7.5）でゲストが設定する。これにより、割り込み元の ESP が不正/ユーザ空間でも既知良好スタックでハンドラが回り、ハンドラ本体は純 mov で書ける（ハンドラ prologue に非-mov なスタック確立は不要）。
+- **RISC-V との対応**: `saved EIP`↔`sepc`、`trap_kind`/`error_code`↔`scause`、`fault_addr`↔`stval`、`IRET`↔`sret`、`TRAP_STACK`↔`sscratch`（カーネルスタック退避）。frame レイアウトの確定はこの既知モデルを踏襲しており、arch/riscv の trap 処理が移植の参考になる。
 
 ## 7. PV-MMIO ABI
 
@@ -156,7 +157,7 @@ offset  field
 ### 7.1 アドレスマップ
 
 ```
-0x1FF0_0000 .. 0x1FF0_0FFF   PV-CPU        (pv-kernel)   IDT_BASE / INTR_MASK / IRET
+0x1FF0_0000 .. 0x1FF0_0FFF   PV-CPU        (pv-kernel)   IDT_BASE / INTR_MASK / IRET / TRAP_STACK
 0x1FF0_1000 .. 0x1FF0_1FFF   PV-CONSOLE    (pv-min)      PUTC / STATUS
 0x1FF0_2000 .. 0x1FF0_2FFF   PV-TIMER      (pv-min)      TICKS / ONESHOT
 0x1FF0_3000 .. 0x1FF0_3FFF   PV-IRQ        (pv-kernel)   PENDING / EOI
@@ -189,9 +190,9 @@ read 専用レジスタへの write、write 専用への read、未定義オフ�
 
 ### 7.5 PV-CPU（pv-kernel, draft — 意味は L0.5 後に確定）
 
-`IDT_BASE`（trap ベクタ表 base）/ `INTR_MASK`（cli/sti 相当, 0=有効）/ `IRET`（§6.3 frame から復帰）。
+`IDT_BASE`（trap ベクタ表 base）/ `INTR_MASK`（cli/sti 相当, 0=有効）/ `IRET`（§6.3 frame から復帰）/ `TRAP_STACK`（trap 進入時に機械が frame を積み ESP に据える既知良好スタック, §6.3）。
 
-> RISC-V 対応: trap CSR（`stvec`=IDT_BASE, `sstatus.SIE`=INTR_MASK, `sret`=IRET）+ SBI（カーネルがプラットフォームに特権操作を依頼する役割）に相当。SBI の構造を PV-CPU の設計参考にする。
+> RISC-V 対応: trap CSR（`stvec`=IDT_BASE, `sstatus.SIE`=INTR_MASK, `sret`=IRET, `sscratch`=TRAP_STACK）+ SBI（カーネルがプラットフォームに特権操作を依頼する役割）に相当。SBI の構造を PV-CPU の設計参考にする。
 
 ### 7.6 PV-IRQ（pv-kernel, draft）
 

--- a/linux-mov/X86MOV32-SPEC.md
+++ b/linux-mov/X86MOV32-SPEC.md
@@ -1,255 +1,172 @@
-# x86mov32 — canonical mov-only machine specification
+# x86mov32 — 機械仕様
 
-> Version: **0.2-draft**
-> 状態: base invariant（§3–§6, §9）は凍結対象。PV 拡張（§7）とプロファイル境界は version 付きで進化する。
->
-> 本書が一次的・正典的な machine 定義である。`DESIGN.md`（Linux/x86mov32 移植ロードマップ）は本書に従属する。
->
-> **名前**: `x86mov32` = x86(i386) サブセット encoding + mov 制約 + 32bit。
-> **0.2 での方針転換**: x86mov32 を「x86 の一種」ではなく **独立した新アーキテクチャ** として扱う（§1）。これにより 0.1-draft にあった股裂き（segment mov・`int 0x80`・EFLAGS trap frame・「x86 が base に conform」）を解消した。
+> version 0.2-draft ／ 本書が x86mov32 という機械の正典定義。`DESIGN.md` はこれを Linux に適用するロードマップで、本書に従属する。
+
+x86mov32 は「ほぼ `mov` のみの命令列で計算・I/O・OS を実行する 32bit 機械」。エンコーディングは i386 のサブセットで、実 x86 はこの機械語をそのまま実行できる。
+
+---
 
 ## 1. 立脚点：x86mov32 は base ISA、x86 はその拡張
 
-x86mov32 を「ほぼ `mov` のみの **base ISA**」として定義し、**普通の x86 を「x86mov32 に大量の拡張を積んだもの」と位置づける**。RISC-V の `RV32I` + `M/A/F/D/C…` と同じモジュラ ISA 観である。Linux 移植も新アーキ `arch/x86mov32/` を起こす作法で進める（x86 の荷物を継承しない）。
+x86mov32 を「ほぼ `mov` だけの **base ISA**」と定義し、普通の x86 を「x86mov32 に拡張を積んだもの」と見る（RISC-V の `RV32I` + `M/A/F/D` と同じモジュラ ISA 観）。x86 との関係は2軸に分かれる。
 
-> **参照アーキは RISC-V (rv32)**。x86mov32 は MMIO-only I/O（§1b）・device tree によるハードウェア記述・単一 trap ベクタ（§6.3）という点で構造的に RISC 的であり、Linux 側の移植も `arch/riscv` 32bit を主 template とする（`arch/x86` ではない）。trap モデルや CLINT/PLIC/SBI 相当の platform interface を既知の良設計として移植できる（§6.3, §7.4–§7.6 の注を参照）。
+**(a) 計算 — 拡張は base に還元できる。** x86 の算術・`cmp`/`jcc`・FP・SIMD は、すべて base の `mov` 列に還元できる（「mov はチューリング完全」。llvm-mov が行う lowering）。この層で実 x86 は x86mov32-base を native に実行する。
 
-x86 と x86mov32 の関係は **2 つの軸**に分けると正確になる：
+**(b) システム — MMIO は x86 と共有、特権命令だけが x86 専用。** x86 のシステム面は2つに分かれる：
+- **MMIO**（device アドレスへの `mov` でデバイスにアクセス）は x86 native の機構で、`mov` で表現でき UC 順序ごと x86 と共有できる。
+- **特権命令**（ポート I/O・`lgdt`/`lidt`/`mov CRn`/`sti`/`iret`/`wrmsr`）は `mov` で表現できない x86 専用拡張。
 
-### (a) 計算拡張 — base に還元可能
-
-x86 の算術 / `cmp`+`jcc` / FP / SIMD / 文字列命令などは、すべて base の `mov` 列に **一方向に還元できる**。これが「mov はチューリング完全」の正体であり、llvm-mov が実装している lowering そのもの。すなわち
-
-```
-x86 の計算 ISA = x86mov32-base + {計算拡張}      （計算拡張は base に還元可能）
-```
-
-- **この層では実 x86 は x86mov32-base の素直な実装**：`mov`/`jmp`/`call`/`ret` を同じ結果で実行する。x86 は計算コアに native に conform する。
-
-### (b) システム面 — MMIO 機構は x86 と共有、特権命令だけが x86 専用
-
-x86 のシステム面は **2 つの下位機構**に分かれる。両者を混同しないことが肝心：
-
-- **MMIO（device address への `mov` でデバイスにアクセス）** — x86 が **native に持つ機構**。`mov` でそのまま表現でき、強い順序（UC メモリ型相当, §5）も含めて **x86mov32 と x86 で共有できる**。
-- **特権命令**（`in`/`out` のポート I/O・`lgdt`/`lidt`・`mov CRn`・`cli`/`sti`・`iret`・`wrmsr`）— mov で表現できない専用オペコード。これが **x86 専用・base に還元できない拡張**。
-
-x86mov32 は **MMIO 機構だけを採用し、ポート I/O と特権命令を捨てる**（RISC-V/ARM と同じ **MMIO-only I/O モデル**）。x86 のシステム効果（console・timer・CR3・IDT・割り込み）はすべて、共有 MMIO 機構の上のレジスタ（§7 PV-*）として **再表現**する。
-
-- ゆえに PV-MMIO は「x86mov32 独自の並行システム」ではなく、**x86 と共有する MMIO 機構の上に必要なデバイス/制御レジスタを定義したもの**。エンコーディングも意味（mov + UC 順序）も x86 と一致する。
-- 帰結: **x86-host 実行層の負担は小さい**。PV-CONSOLE/PV-TIMER は通常の MMIO デバイスを該当アドレスに map するだけ（shim ほぼゼロ）。shim が要るのは **MMIO レジスタが x86 の特権操作をラップする箇所だけ**（例: PV-CPU/PV-MMU の CR3・IDT 設定 → 実 x86 では `mov CRn`/`lidt` に翻訳）。
-
-### (c) プラットフォーム契約
-
-base の「マップ規約・fault 配送・boot」（§5/§6/§9）は x86 上で無料では成り立たない（ページング off の x86 は任意アドレスで fault しない）。x86-host 実行層がページング等でこれを敷く。
-
-### まとめ
+x86mov32 は MMIO 機構だけを採用し（MMIO-only I/O）、特権命令を捨てる。x86 のシステム効果（console・timer・ページング・割り込み）はすべて MMIO レジスタ（§7 PV-*）として再表現する。
 
 ```
-実 x86            = base + {計算拡張} + {MMIO(共有)} + {ポートI/O・特権命令 (x86専用)}
-x86mov32          = base + {計算拡張は mov に lower} + {MMIO(共有) 上に PV-* デバイス/制御レジスタ}
+実 x86    = base + 計算拡張 + MMIO(共有) + ポートI/O・特権命令(x86専用)
+x86mov32  = base + (計算拡張は mov に lower) + MMIO(共有) 上の PV-* レジスタ
 ```
 
-- **計算コア**: 実 x86 が native に conform（§1a）。
-- **MMIO 機構**: x86 と共有（§1b）。x86mov32 はこれを唯一の I/O 機構とする。
-- **x86 専用拡張**（ポート I/O・特権命令）: x86mov32 は持たず、その効果を共有 MMIO 上の PV-* レジスタで再表現。x86-host 実行層はこのラップ箇所だけ shim する。
-- **プラットフォーム契約**（マップ規約・fault・boot, §1c）: x86-host 実行層がページング等で敷く。
+**実装の役割分担。** **movie86** は base + PV を直接実装する**リファレンス実装**。**実 x86 host** は base の計算コアを native 実行し、PV システム拡張とプラットフォーム契約（マップ・fault・boot）を薄い **substrate**（実特権命令を使う ring0 層、`DESIGN.md` §3.5）が供給する。両実装は §8 の conformance テストで揃える。
 
-movie86 は base + MMIO + PV-* を直接実装するリファレンス実装。conformance は §8 のテストで定義され、movie86 と x86-host 実行層の双方がそれを通すことで担保する。
+> movie86 の現行仕様（userspace runner 挙動・movfuscator 実行・寛容メモリ・`0x1FFE_0000` ABI）の互換は **非ゴール**。movie86 を x86mov32 リファレンス機械へ自由に再形成してよい。
 
-## 2. プロファイル（profile）
+---
 
-実装もゲストも「movie86」ではなく **named profile** を宣言する。
+## 2. プロファイル
+
+実装もゲストも profile 名で対象を宣言する。
 
 | profile | 含むもの | 用途 |
 |---|---|---|
 | **x86mov32-base** | §3 ISA + §4 レジスタ + §5 メモリ + §6 fault + §9 boot | 計算 + halt/exit。デバイス無し |
-| **x86mov32-pv-min** | base + §7.3 PV-CONSOLE + §7.4 PV-TIMER（割り込み無しの read） | 極小カーネルが print / tick poll |
-| **x86mov32-pv-kernel** | pv-min + §7.5 PV-CPU + §7.6 PV-IRQ + §7.7 PV-MMU + §6.3 trap 配送 | Linux/x86mov32 級（demand paging・割り込み・preemption）|
+| **x86mov32-pv-min** | base + §7 PV-CONSOLE + PV-TIMER（read のみ） | 極小カーネルが print / tick poll |
+| **x86mov32-pv-kernel** | pv-min + PV-CPU + PV-IRQ + PV-MMU + trap 配送 | Linux 級（demand paging・割り込み・preemption）|
 
-**規則**:
-- 「X は x86mov32-pv-min を狙う」と profile 名で書く。movie86 は各 profile のリファレンス実装。
-- **x86-host 実行層**は profile ではなく「実 x86/qemu 上で指定 profile を供給する層」。同名 profile の §8 テストを通すか、通らない差分を conformance gap として文書化した場合のみ「その profile を host できる」と言える。
-- **design stance: movie86 の AS-IS 仕様の互換は非ゴール（best-effort ですらない）**。movie86 を x86mov32 のリファレンス機械へ再形成する際、現行の userspace-runner 挙動・movfuscator 実行・寛容な flat メモリ・`0x1FFE_0000` ABI を保存する義務は一切ない。旧 movfuscator 互換（`int 0x80`・SIGILL/SIGSEGV dispatch・segment-mov）は **x86mov32 の一部ではない**（§3.3）。既存資産（movfuscator-wasm / explorer 等）が壊れることは許容する。
+---
 
 ## 3. ISA サブセット（base, 凍結）
 
-### 3.1 「mov-only」の定義
+許可される命令はニーモニックで定義する：
 
-**意味クラスではなくニーモニックで定義する。** base で許可されるのは以下のみ：
+- **`mov`**（全幅・全アドレッシングモード。control/segment レジスタへの mov は不可 — 特権効果は §7 の PV-MMIO mov で表す）
+- **最小の制御転送**: `jmp rel32`(E9) / `jmp r/m32`(FF /4) / `call rel32`(E8) / `ret`(C3) / `push r32` / `pop r32`
 
-- `mov`（全幅・全アドレッシングモード。ただし control register / segment register への mov は base では**不許可** — 特権操作は §7 で PV-MMIO mov に写像）
-- 制御転送の最小集合: `jmp rel32`(E9), `jmp r/m32`(FF /4), `call rel32`(E8), `ret`(C3), `push r32`(50–57), `pop r32`(58–5F)
+不可: `cmp`/`jcc`/算術/FP/SIMD/`int`/`lock`/REX。条件分岐・算術・FP は llvm-mov が mov 列に lower する。
 
-> 注: 純粋主義の「100% mov（jmp すら無し）」は本 spec の非目標。本機械は **mov + 最小制御転送**（movie86/llvm-mov の既定 "mov+jmp" に一致）。
+**観測可能な EFLAGS は無い。** 許可命令はフラグを意味的に読まない（条件分岐は branchless dispatch に lower 済み）。実 x86 上で物理 EFLAGS が変化しても、x86mov32 プログラムはそれを観測してはならない。
 
-### 3.2 明示的に不許可（base）
+旧 movfuscator の機構（`int 0x80`・`mov cs` 経由の SIGILL/SIGSEGV dispatch・segment mov）は **x86mov32 の一部ではない**。
 
-`cmp`/`jcc`/算術命令/FP/SIMD/REX/`lock` prefix/`int`/segment-mov/control-reg-mov。条件分岐・算術・FP は llvm-mov が mov 列に lower 済み（README ステージ 7a–7h）。
+---
 
-### 3.3 x86mov32 に含まれないもの（旧 movfuscator 機構）
-
-以下は **x86mov32 の一部ではない**（base / pv-* いずれにも現れず、互換も非ゴール §2）：
-
-- `int 0x80` syscall（x86mov32 では PV-MMIO + §9 の exit/halt が syscall/終了の唯一の機構）
-- SIGILL/SIGSEGV dispatch（`mov cs, r16` 経路を含む movfuscator trampoline）
-- segment register への mov
-
-### 3.4 EFLAGS
-
-base / pv に **観測可能な EFLAGS は存在しない**。許可命令はフラグを意味的に読まない（条件分岐は branchless dispatch に lower 済み）。実 x86 host 上では物理 EFLAGS が副作用で変わるが、x86mov32 プログラムはそれを観測してはならない（移植性条件）。trap frame に EFLAGS は含めない（§6.3）。
-
-## 4. レジスタ状態（base, 凍結）
+## 4. レジスタ（base, 凍結）
 
 - 8 本の 32bit GPR（EAX..EDI）、EIP、ESP。
-- セグメントは概念として存在しない（flat。x86mov32 は segmentation を持たないアーキ）。x86 host 上では flat descriptor で実現するが、それは host 実装の都合。
-- EFLAGS は §3.4 の通り非観測。
+- セグメントは存在しない（flat）。x86 host 上は flat descriptor で実現するが host の都合。
+- EFLAGS は非観測（§3）。
 
-## 5. メモリモデル（base, 凍結）
+---
+
+## 5. メモリ（base, 凍結）
 
 - フラット 32bit バイトアドレス空間、リトルエンディアン。
-- **マップ規約（Codex round-2 対応）**: x86mov32 は **明示的にマップされた領域のみ**有効。base/pv-min では「PT_LOAD + BSS（§9）+ boot stack（§9 で確保する実装定義領域）+ 宣言された PV-MMIO 領域（§7）」だけがマップされ、それ以外へのアクセスは fault（§6.1）。bare-metal 物理メモリモデルではない。
-  - **実装モデル（L0）**: movie86 は現状の flat 配列を **interval map**（マップ済み区間の集合）に置き換え、区間外を fault とする。base/pv-min L0 では **presence（マップの有無）判定で十分**で、W^X / `p_flags` の権限強制は後段（保護を導入する pv-kernel）まで不要。
-- **アラインメント**: 非整列アクセスは許可（`#AC` 相当は発生しない）。
-- **自己書き換えコード**: base では **不許可**（W^X 前提）。Linux のテストパッチ機構（alternatives / static-keys / jump-label / ftrace / kprobes / paravirt-patch）は §7.8 PV-TEXTPATCH か「対象 config で全テキスト改変を無効化」のいずれかで扱う（§10 未確定、ただし mainline 移植の必須検討事項）。
-- **MMIO は唯一の I/O 機構**（ポート I/O は持たない, §1b）。MMIO 領域（§7）アクセスは strong ordering（プログラム順, x86 の UC メモリ型相当 — この機構と順序は x86 と共有する）。UP・単一スレッド前提、投機・並べ替え無し。
+- **マップされた領域だけが有効。** base/pv-min でマップされるのは「PT_LOAD + BSS + boot stack（§9）+ 宣言された PV-MMIO 領域（§7）」のみ。範囲外アクセスは fault（§6）。実装は区間集合（interval map）で表す。
+- 非整列アクセスは許可（`#AC` 相当は起きない）。
+- **自己書き換えコードは base で不可**（W^X 前提）。Linux のテストパッチ（alternatives/static-key/ftrace 等）は §7 PV-TEXTPATCH か、対象 config で無効化（§10）。
+- **MMIO は唯一の I/O 機構**（ポート I/O は無い）。MMIO 領域は strong ordering（x86 UC 相当、x86 と共有）。UP・単一スレッド前提。
 
-## 6. fault / trap 意味論（base, 凍結）
+---
 
-「x86-like」とは **「許可された操作に対する同期 fault 境界が x86 と同じ」** の意であり、x86 protected-mode 挙動そのものではない（x86mov32 は独自アーキ）。
+## 6. fault / trap（凍結）
 
-### 6.1 同期 fault（base/pv-min, 凍結）
+「x86-like」とは「許可された操作に対する同期 fault 境界が x86 と同じ」の意で、x86 protected-mode そのものではない。
 
-| 条件 | x86mov32 base の挙動 |
+### 6.1 同期 fault（base/pv-min）
+
+| 条件 | 挙動 |
 |---|---|
-| 未マップ領域（§5 のマップ外）への load/store | fault。ハンドラ未設定なら停止 |
-| 未マップ領域からの命令フェッチ / decode 不能・非許可エンコード | fault（停止） |
-| MMIO 不正オフセット / 不正方向（§7） | fault（停止）。silent success にしない（movie86 の trap-on-unknown を継承） |
+| マップ外への load/store | fault。ハンドラ未設定なら停止 |
+| マップ外フェッチ / 不正・非許可エンコード | fault（停止）|
+| MMIO 不正オフセット/方向（§7） | fault（停止。silent success にしない）|
 
-base/pv-min では除算命令を持たない（llvm-mov が mov 列に lower）ため除算 fault は発生しない。
+base/pv-min は除算命令を持たない（llvm-mov が lower）ため除算 fault は起きない。
 
-### 6.2 demand paging / page fault は pv-kernel の機能
+### 6.2 page fault は pv-kernel の機能
 
-「ページ不在」は base/pv-min には存在しない（マップは静的）。**demand paging・COW・vmalloc fault・`copy_*_user` の fixup** は x86mov32 が pv-kernel で定義する page fault 機構（§7.7 PV-MMU + §6.3 配送）に依存する。Linux/x86mov32 はこれを使う。
+「ページ不在」は base/pv-min には無い（マップは静的）。demand paging・COW・`copy_*_user` fixup は pv-kernel の PV-MMU + trap 配送（§7）に依存する。
 
-### 6.3 trap frame と配送（pv-kernel, **本 0.2 で形を確定** — Codex round-2 対応）
+### 6.3 trap frame（pv-kernel）
 
-非同期/同期 trap をハンドラに配送するとき、機械が積む **x86mov32 trap frame** を以下に確定する（`IRET` ABI 破壊を将来回避するため今決める）：
-
-```
-offset  field
-+0x00   saved EIP        (fault した命令、または次命令)
-+0x04   saved ESP
-+0x08   EAX .. +0x24 EDI (8 GPR)
-+0x28   fault_addr       (#PF 相当の CR2 等価。該当しない trap では 0)
-+0x2C   error_code       (trap 種別 + アクセス種別ビット)
-+0x30   trap_kind        (PAGE/ILLEGAL/MMIO/IRQ ...)
-```
-
-- **EFLAGS は含めない**（§3.4 と整合）。x86mov32 は x86 の exception frame を模さず、自前の frame を定義する。Linux/x86mov32 の `pt_regs` 相当はこの frame に合わせて新規定義する（arch/x86mov32 側の責務）。
-- `IRET`（§7.5）はこの frame から GPR/EIP/ESP を復帰する。割り込みは resume 点まで masked のまま（原子的再開）。
-- **frame の置き場所と trap stack（round-4, 詳細は L2 で確定）**: 機械はゲストが事前に登録した **trap stack** に frame を積み、ハンドラ進入時に **ESP=その trap stack** とする。trap stack は PV-CPU `TRAP_STACK` レジスタ（§7.5）でゲストが設定する。これにより、割り込み元の ESP が不正/ユーザ空間でも既知良好スタックでハンドラが回り、ハンドラ本体は純 mov で書ける（ハンドラ prologue に非-mov なスタック確立は不要）。
-  - **未確定（draft, L2 で決める, round-5）**: `TRAP_STACK` が top-of-stack か frame base か / 機械が frame サイズ分 decrement するか / **nested trap**（trap stack 上で再 fault した場合に frame を上書きするか別領域か）/ frame 構築の前後で async IRQ を mask するタイミング。pv-min（割り込み無し）では未使用なので L0 はブロックしない。
-- **RISC-V との対応**: `saved EIP`↔`sepc`、`trap_kind`/`error_code`↔`scause`、`fault_addr`↔`stval`、`IRET`↔`sret`、`TRAP_STACK`↔`sscratch`（カーネルスタック退避）。frame レイアウトの確定はこの既知モデルを踏襲しており、arch/riscv の trap 処理が移植の参考になる。
-
-## 7. PV-MMIO ABI
-
-特権操作のうち base ISA で表現できないものを、予約アドレスへの `mov` に写像する。CPU は依然 `mov` のみ実行し、機械が反応する。
-
-### 7.1 アドレスマップ
+trap をハンドラへ配送するとき機械が積む frame：
 
 ```
-0x1FF0_0000 .. 0x1FF0_0FFF   PV-CPU        (pv-kernel)   IDT_BASE / INTR_MASK / IRET / TRAP_STACK
-0x1FF0_1000 .. 0x1FF0_1FFF   PV-CONSOLE    (pv-min)      PUTC / STATUS
-0x1FF0_2000 .. 0x1FF0_2FFF   PV-TIMER      (pv-min)      TICKS / ONESHOT
-0x1FF0_3000 .. 0x1FF0_3FFF   PV-IRQ        (pv-kernel)   PENDING / EOI
-0x1FF0_4000 .. 0x1FF0_4FFF   PV-MMU        (pv-kernel)   PGDIR / FLUSH / FAULT_ADDR
-0x1FF0_5000 .. 0x1FF0_5FFF   PV-TEXTPATCH  (pv-kernel?)  予約（§7.8, §10 未確定）
-0x1FF0_FF00 .. 0x1FF0_FFFF   PV-DISCOVERY  (all)         MAGIC / VERSION / FEATURE_BITS
++0x00  saved EIP        +0x28  fault_addr   (#PF の CR2 相当、無ければ 0)
++0x04  saved ESP        +0x2C  error_code   (trap 種別 + アクセス種別)
++0x08  EAX..EDI (8 GPR) +0x30  trap_kind    (PAGE/ILLEGAL/MMIO/IRQ ...)
 ```
-（旧 movfuscator の `0x1FFE_0000` ABI は x86mov32 では予約しない。§7.1 の窓は自由に設計してよい。）
-全レジスタ 4byte 幅・自然整列アクセスのみ有効。範囲外/不正方向は fault（§6.1）。
 
-### 7.2 アクセス規約
+- **EFLAGS は含めない**（§4 と整合）。Linux の `pt_regs` 相当はこの frame に合わせて新規定義する。
+- `IRET`（§7）はこの frame から GPR/EIP/ESP を復帰し、resume 点まで割り込みを mask したまま原子的に再開する。
+- 機械はゲストが `TRAP_STACK`（§7）に登録した既知良好スタックに frame を積み、ハンドラ進入時に ESP をそこへ据える。これでハンドラ本体は純 mov で書ける。
+- RISC-V 対応: `saved EIP`=`sepc`、`trap_kind`/`error_code`=`scause`、`fault_addr`=`stval`、`IRET`=`sret`、`TRAP_STACK`=`sscratch`。
+- **未確定（L2 で確定）**: `TRAP_STACK` が top か base か、機械が frame サイズ分 decrement するか、nested trap での frame 扱い、割り込み mask のタイミング。pv-min（割り込み無し）では未使用。
 
-read 専用レジスタへの write、write 専用への read、未定義オフセットアクセスはいずれも fault。
+---
 
-### 7.3 PV-CONSOLE（pv-min, 凍結候補）
+## 7. PV-MMIO
 
-| off | 名前 | RW | 意味 |
-|---|---|---|---|
-| +0x00 | `PUTC` | W | 下位 8bit を 1 文字出力 |
-| +0x04 | `STATUS` | R | bit0=TX ready |
+特権操作を、予約アドレスへの `mov` に写像する。CPU は `mov` のみ実行し、機械が反応する。
 
-### 7.4 PV-TIMER（pv-min は read のみ / 割り込みは pv-kernel）
+### アドレスマップ
 
-| off | 名前 | RW | 意味 |
-|---|---|---|---|
-| +0x00 | `TICKS` | R | 単調増加 tick（周波数は §7.9 VERSION 経由）|
-| +0x04 | `ONESHOT` | W | 次回タイマ通知までの tick。配送は §7.6（pv-kernel）|
+```
+0x1FF0_0000   PV-CPU       (pv-kernel)  IDT_BASE / INTR_MASK / IRET / TRAP_STACK
+0x1FF0_1000   PV-CONSOLE   (pv-min)     PUTC / STATUS
+0x1FF0_2000   PV-TIMER     (pv-min)     TICKS / ONESHOT
+0x1FF0_3000   PV-IRQ       (pv-kernel)  PENDING / EOI
+0x1FF0_4000   PV-MMU       (pv-kernel)  PGDIR / FLUSH / FAULT_ADDR
+0x1FF0_5000   PV-TEXTPATCH (pv-kernel)  予約（§10）
+0x1FF0_FF00   PV-DISCOVERY (all)        MAGIC / VERSION / FEATURE_BITS
+```
 
-> RISC-V 対応: CLINT の `mtime`(=TICKS) / `mtimecmp`(=ONESHOT) とほぼ同型。実装・カーネル側ドライバとも CLINT を参考にできる。
+全レジスタ 4byte・自然整列のみ有効。範囲外/不正方向、R 専用への write、W 専用への read は fault（§6.1）。実アドレスは device tree で記述し（下記）、上表は既定/参照値。
 
-### 7.5 PV-CPU（pv-kernel, draft — 意味は L0.5 後に確定）
+| 領域 | レジスタ | 内容 |
+|---|---|---|
+| **PV-CONSOLE** (pv-min) | `PUTC` (W) | 下位 8bit を 1 文字出力 |
+| | `STATUS` (R) | bit0 = TX ready |
+| **PV-TIMER** (pv-min) | `TICKS` (R) | 単調増加 tick（周波数は VERSION 経由）|
+| | `ONESHOT` (W) | 次回タイマ通知までの tick（配送は pv-kernel）|
+| **PV-CPU** (pv-kernel) | `IDT_BASE` / `INTR_MASK` / `IRET` / `TRAP_STACK` | trap ベクタ / cli・sti / 復帰 / trap スタック。RISC-V の trap CSR + SBI 相当 |
+| **PV-IRQ** (pv-kernel) | `PENDING` (R) / `EOI` (W) | 初段 poll 型、後に強制ジャンプ型。CLINT/PLIC 相当 |
+| **PV-MMU** (pv-kernel) | `PGDIR` / `FLUSH` / `FAULT_ADDR` | ページディレクトリ base / TLB invalidate / 直近 page fault アドレス。ページテーブル形式は独自定義 |
+| **PV-TEXTPATCH** (予約) | — | テキストパッチ（alternatives/static-key 等）を許す場合の host 承認パッチ機構。代替は config 無効化（§10）|
+| **PV-DISCOVERY** (all) | `MAGIC` / `VERSION` / `FEATURE_BITS` | 機械の識別 / spec version / 実装 profile。実行時に profile を確認できる |
 
-`IDT_BASE`（trap ベクタ表 base）/ `INTR_MASK`（cli/sti 相当, 0=有効）/ `IRET`（§6.3 frame から復帰）/ `TRAP_STACK`（trap 進入時に機械が frame を積み ESP に据える既知良好スタック, §6.3）。
+**device tree。** ハードウェア構成（メモリマップ・PV-* の MMIO アドレス・割り込み番号）は DTB で記述し、カーネルは起動時に DTB から discover する（riscv/arm 流）。上のアドレスマップは参照 DT。compatible は `x86mov32,pv-console` など。
 
-> RISC-V 対応: trap CSR（`stvec`=IDT_BASE, `sstatus.SIE`=INTR_MASK, `sret`=IRET, `sscratch`=TRAP_STACK）+ SBI（カーネルがプラットフォームに特権操作を依頼する役割）に相当。SBI の構造を PV-CPU の設計参考にする。
+---
 
-### 7.6 PV-IRQ（pv-kernel, draft）
+## 8. conformance
 
-`PENDING`(R, poll 型) / `EOI`(W)。配送: 初段 poll 型（純 mov）、preemption 要件が出たら強制ジャンプ型（trap frame §6.3 を積んで IDT 経由）を追加。
+各実装（movie86 / x86-host substrate）は profile ごとに必須 fixture を全て通す。通らない差分は gap として明示文書化する（沈黙の乖離を禁止）。
 
-> RISC-V 対応: CLINT(software/timer IRQ) + PLIC(外部 IRQ) に相当。irqchip ドライバは PLIC を参考にできる。
+- **base**: 許可命令が動く / 非許可が fault / 非整列 load・store 成功 / マップ外 load・fetch fault / 非許可エンコード fault / boot stack 形状 / exit・halt
+- **pv-min**: PUTC 出力 / STATUS / TICKS 単調増加 / MMIO 不正オフセット fault / DISCOVERY 各フィールド
+- **pv-kernel**（意味確定後）: trap frame レイアウト / IRET 往復 / INTR_MASK / page fault→FAULT_ADDR / PGDIR の VA→PA
 
-### 7.7 PV-MMU（pv-kernel, draft）
+**L0 の最初のテストセット**（具体 fixture）: `putc_ok` / `status_read_ok` / `putc_read_fault` / `status_write_fault` / `mmio_byte_fault` / `mmio_unaligned_fault` / `mmio_bad_offset_fault` / `unmapped_load_fault` / `unmapped_fetch_fault` / `exit_ok`。各 fixture = tiny ELF + 期待 stdout または fault record。
 
-`PGDIR`(W, ページディレクトリ物理 base = ページング有効化)/ `FLUSH`(W, TLB 相当 invalidate)/ `FAULT_ADDR`(R, 直近 page fault のアドレス)。ページテーブル形式は **x86mov32 独自に定義**（x86 PTE 形式の流用可否は L0.5 で判断）。
+---
 
-### 7.8 PV-TEXTPATCH（予約, §10 未確定）
+## 9. boot / calling convention（凍結）
 
-自己書き換え/テキストパッチを安全に行う操作。Linux の alternatives/static-keys/ftrace 等を許す場合に必要。代替は「対象 config で全テキスト改変を無効化」。L0.5 のインベントリでどちらが現実的か判定。
+- ELF32 LE i386, `ET_EXEC`, 静的リンク（`PT_INTERP`/`PT_DYNAMIC` 不可）。初期 EIP = `e_entry`。PT_LOAD + BSS をゼロ初期化。マップされるのはこれらと boot stack と PV-MMIO のみ（§5）。
+- **program boot**（base/pv-min）: 初期スタック = SysV 最小像（argc=0, argv/envp/auxv=NULL）、ESP は argc を指す。boot stack は実装定義の固定領域（L0 テストの決定性のため base/サイズを固定）。
+- **kernel boot**（pv-kernel）: エントリで DTB 物理アドレスを `EBX`、boot magic を `EAX` に渡す（RISC-V の `a1=dtb` 相当）。カーネルは DTB から discover する。
+- 終了 = PV exit / halt。
 
-### 7.9 PV-DISCOVERY（all, 凍結候補）
+---
 
-`MAGIC`(R, 固定値) / `VERSION`(R, spec version) / `FEATURE_BITS`(R, 実装 profile の bit 集合)。実装/ゲスト双方が実行時に profile を確認できる。
+## 10. version 方針
 
-### 7.10 device tree によるハードウェア記述（pv-kernel）
-
-ハードウェア構成（メモリマップ・PV-CONSOLE/TIMER/IRQ/MMU の MMIO アドレス・割り込み番号）は **device tree（DTB）で記述し、カーネルは起動時に DTB から discover する**（riscv/arm 流）。
-
-- §7.1 のハードコード・アドレスマップは **デフォルト/リファレンス DT** という位置づけ。実アドレスは DTB が正。これにより §7.1 を凍結せずに済む（将来のアドレス変更が DT 差し替えで吸収できる）。
-- DTB は起動時にカーネルへ渡す（§9 boot 契約）。movie86・x86-host 実行層の双方が DTB を供給する。
-- PV-* デバイスには専用の DT compatible 文字列を割り当てる（例: `x86mov32,pv-console` / `x86mov32,pv-timer`）。ペリフェラルの *設計* は x86 の馴染んだデバイス（16550 UART 等）を参考にしてよいが、*記述・発見* は DT に統一する。
-
-## 8. conformance（一級の成果物 — 0.2 で必須リスト確定）
-
-各実装（movie86 / x86-host 実行層）は profile ごとに以下の **必須 fixture** を全て通すこと。通らない差分は conformance gap として明示文書化（沈黙の乖離を禁止）。
-
-**base 必須**:
-- decode whitelist（§3.1 許可命令が動く）/ blacklist（§3.2 非許可が fault）
-- 非整列 load/store が成功する
-- 未マップ data アクセスが fault する
-- 未マップ命令フェッチが fault する
-- 非許可エンコードが fault する
-- boot stack 形状（§9）/ exit・halt
-
-**pv-min 必須**: PUTC 出力 / STATUS / TICKS 単調増加 / MMIO 不正オフセット fault / DISCOVERY 各フィールド。
-
-**L0 具体 fixture（実装の最初のテストセット）**: `putc_ok`（PUTC 出力が host に届く）/ `status_read_ok` / `putc_read_fault`（W 専用を read→fault）/ `status_write_fault`（R 専用を write→fault）/ `mmio_byte_fault`（PUTC へ byte store→fault, 4byte 自然整列のみ有効）/ `mmio_unaligned_fault` / `mmio_bad_offset_fault` / `unmapped_load_fault` / `unmapped_fetch_fault` / `exit_ok`。各 fixture は tiny ELF + 期待する stdout または fault record。
-
-**pv-kernel 必須**（0.2 で枠、意味確定後に具体化）: trap frame レイアウト（§6.3）/ IRET 往復 / INTR_MASK 効果 / page fault → FAULT_ADDR / PGDIR による VA→PA。
-
-## 9. boot / calling convention（base, 凍結）
-
-- ELF32 LE i386, `ET_EXEC`, 静的リンク。`PT_INTERP`/`PT_DYNAMIC` 不可。
-- 初期 EIP = `e_entry`。memory は PT_LOAD + BSS をゼロ初期化。これらと PV-MMIO 領域のみがマップされる（§5）。
-- **2 種類の boot 契約**（凍結）:
-  - **program boot**（base / pv-min）: 初期スタック = SysV ABI 最小像（argc=0, argv/envp/auxv=NULL）、ESP は argc を指す。極小プログラム・L1 極小カーネル用。**boot stack は実装定義の固定領域**（base/top と extent を実装が決め、§5 のマップ集合に含める）。L0 テストの決定性のため、この領域の base/サイズを実装で固定する。
-  - **kernel boot**（pv-kernel）: エントリで **DTB 物理アドレスを `EBX` に**、boot magic を `EAX` に渡す（RISC-V の `a0=hartid, a1=dtb` に相当する規約を x86mov32 用に固定）。カーネルは DTB からハードウェアを discover する（§7.10）。今この規約を固定し、将来の破壊的変更を避ける。
-- 終了 = halt（PV exit / halt 機構, §7）。
-
-## 10. version 方針と未確定事項
-
-- **凍結（0.x で変えない）**: §3 ISA、§4 レジスタ、§5 メモリ（マップ規約含む）、§6.1 同期 fault、§6.3 trap frame レイアウト、§9 boot。
-- **version 付きで進化**: §7.5–§7.7 の詳細意味論、ページテーブル形式、割り込み配送モデル、§7.8 テキストパッチ方針。
-- **0.3 への入力 = L0.5「Linux/x86mov32 feasibility kill-test」→ 完了**（[`L0.5-KILLTEST.md`](./L0.5-KILLTEST.md)、二者独立検証で **SURVIVES**）。結論: 最小 config（UP/nommu/no-SMC/no-jumplabel）にカーネル側 config BLOCKER は無く、難所は無効化 or 純 C 化できる。llvm-mov の irreducible 要件は **(1) volatile codegen 正しさ (2) 空+operand 付き memory バリア (3) i386 varargs (4) i64 helper lower（libgcc 除算は emit しない）(5) C/PV irq-flag**。任意制約 inline asm は first boot 不要。entry/特権パスは PV-MMIO mov 列として `arch/x86mov32` に手書き（link/boot 必須）。
+- **凍結（0.x で変えない）**: §3 ISA、§4 レジスタ、§5 メモリ、§6.1 同期 fault、§6.3 trap frame レイアウト、§9 boot。
+- **進化（version 付き）**: PV-CPU/IRQ/MMU の詳細意味論、ページテーブル形式、割り込み配送、PV-TEXTPATCH 方針。
+- **feasibility**: `L0.5-KILLTEST.md` 参照（判定 SURVIVES）。最小 config にカーネル側の阻害要因は無く、llvm-mov の必須要件は volatile codegen / 空+operand バリア / i386 varargs / i64 helper lower / C irq-flag。

--- a/linux-mov/X86MOV32-SPEC.md
+++ b/linux-mov/X86MOV32-SPEC.md
@@ -248,4 +248,4 @@ read 専用レジスタへの write、write 専用への read、未定義オフ�
 
 - **凍結（0.x で変えない）**: §3 ISA、§4 レジスタ、§5 メモリ（マップ規約含む）、§6.1 同期 fault、§6.3 trap frame レイアウト、§9 boot。
 - **version 付きで進化**: §7.5–§7.7 の詳細意味論、ページテーブル形式、割り込み配送モデル、§7.8 テキストパッチ方針。
-- **0.3 への入力 = L0.5「Linux/x86mov32 feasibility kill-test」**（DESIGN.md）。単なる棚卸しでなく **kill-test** とする。最有力の致命要因は *命令選択ではなく* **inline asm の意味論** — `asm volatile`・`"memory"` clobber・`asm goto`・exception-table / fault fixup パターン。llvm-mov がコンパイラバリアと faultable asm/制御フロー fixup をモデル化できなければ、atomics 以前に詰む（UP atomics は当面ごまかせるが、barrier/fixup/asm-goto 契約はごまかせない）。
+- **0.3 への入力 = L0.5「Linux/x86mov32 feasibility kill-test」→ 完了**（[`L0.5-KILLTEST.md`](./L0.5-KILLTEST.md)、二者独立検証で **SURVIVES**）。結論: 最小 config（UP/nommu/no-SMC/no-jumplabel）にカーネル側 config BLOCKER は無く、難所は無効化 or 純 C 化できる。llvm-mov の irreducible 要件は **(1) volatile codegen 正しさ (2) 空+operand 付き memory バリア (3) i386 varargs (4) i64 helper lower（libgcc 除算は emit しない）(5) C/PV irq-flag**。任意制約 inline asm は first boot 不要。entry/特権パスは PV-MMIO mov 列として `arch/x86mov32` に手書き（link/boot 必須）。

--- a/linux-mov/X86MOV32-SPEC.md
+++ b/linux-mov/X86MOV32-SPEC.md
@@ -1,0 +1,251 @@
+# x86mov32 — canonical mov-only machine specification
+
+> Version: **0.2-draft**
+> 状態: base invariant（§3–§6, §9）は凍結対象。PV 拡張（§7）とプロファイル境界は version 付きで進化する。
+>
+> 本書が一次的・正典的な machine 定義である。`DESIGN.md`（Linux/x86mov32 移植ロードマップ）は本書に従属する。
+>
+> **名前**: `x86mov32` = x86(i386) サブセット encoding + mov 制約 + 32bit。
+> **0.2 での方針転換**: x86mov32 を「x86 の一種」ではなく **独立した新アーキテクチャ** として扱う（§1）。これにより 0.1-draft にあった股裂き（segment mov・`int 0x80`・EFLAGS trap frame・「x86 が base に conform」）を解消した。
+
+## 1. 立脚点：x86mov32 は base ISA、x86 はその拡張
+
+x86mov32 を「ほぼ `mov` のみの **base ISA**」として定義し、**普通の x86 を「x86mov32 に大量の拡張を積んだもの」と位置づける**。RISC-V の `RV32I` + `M/A/F/D/C…` と同じモジュラ ISA 観である。Linux 移植も新アーキ `arch/x86mov32/` を起こす作法で進める（x86 の荷物を継承しない）。
+
+> **参照アーキは RISC-V (rv32)**。x86mov32 は MMIO-only I/O（§1b）・device tree によるハードウェア記述・単一 trap ベクタ（§6.3）という点で構造的に RISC 的であり、Linux 側の移植も `arch/riscv` 32bit を主 template とする（`arch/x86` ではない）。trap モデルや CLINT/PLIC/SBI 相当の platform interface を既知の良設計として移植できる（§6.3, §7.4–§7.6 の注を参照）。
+
+x86 と x86mov32 の関係は **2 つの軸**に分けると正確になる：
+
+### (a) 計算拡張 — base に還元可能
+
+x86 の算術 / `cmp`+`jcc` / FP / SIMD / 文字列命令などは、すべて base の `mov` 列に **一方向に還元できる**。これが「mov はチューリング完全」の正体であり、llvm-mov が実装している lowering そのもの。すなわち
+
+```
+x86 の計算 ISA = x86mov32-base + {計算拡張}      （計算拡張は base に還元可能）
+```
+
+- **この層では実 x86 は x86mov32-base の素直な実装**：`mov`/`jmp`/`call`/`ret` を同じ結果で実行する。x86 は計算コアに native に conform する。
+
+### (b) システム面 — MMIO 機構は x86 と共有、特権命令だけが x86 専用
+
+x86 のシステム面は **2 つの下位機構**に分かれる。両者を混同しないことが肝心：
+
+- **MMIO（device address への `mov` でデバイスにアクセス）** — x86 が **native に持つ機構**。`mov` でそのまま表現でき、強い順序（UC メモリ型相当, §5）も含めて **x86mov32 と x86 で共有できる**。
+- **特権命令**（`in`/`out` のポート I/O・`lgdt`/`lidt`・`mov CRn`・`cli`/`sti`・`iret`・`wrmsr`）— mov で表現できない専用オペコード。これが **x86 専用・base に還元できない拡張**。
+
+x86mov32 は **MMIO 機構だけを採用し、ポート I/O と特権命令を捨てる**（RISC-V/ARM と同じ **MMIO-only I/O モデル**）。x86 のシステム効果（console・timer・CR3・IDT・割り込み）はすべて、共有 MMIO 機構の上のレジスタ（§7 PV-*）として **再表現**する。
+
+- ゆえに PV-MMIO は「x86mov32 独自の並行システム」ではなく、**x86 と共有する MMIO 機構の上に必要なデバイス/制御レジスタを定義したもの**。エンコーディングも意味（mov + UC 順序）も x86 と一致する。
+- 帰結: **x86-host 実行層の負担は小さい**。PV-CONSOLE/PV-TIMER は通常の MMIO デバイスを該当アドレスに map するだけ（shim ほぼゼロ）。shim が要るのは **MMIO レジスタが x86 の特権操作をラップする箇所だけ**（例: PV-CPU/PV-MMU の CR3・IDT 設定 → 実 x86 では `mov CRn`/`lidt` に翻訳）。
+
+### (c) プラットフォーム契約
+
+base の「マップ規約・fault 配送・boot」（§5/§6/§9）は x86 上で無料では成り立たない（ページング off の x86 は任意アドレスで fault しない）。x86-host 実行層がページング等でこれを敷く。
+
+### まとめ
+
+```
+実 x86            = base + {計算拡張} + {MMIO(共有)} + {ポートI/O・特権命令 (x86専用)}
+x86mov32          = base + {計算拡張は mov に lower} + {MMIO(共有) 上に PV-* デバイス/制御レジスタ}
+```
+
+- **計算コア**: 実 x86 が native に conform（§1a）。
+- **MMIO 機構**: x86 と共有（§1b）。x86mov32 はこれを唯一の I/O 機構とする。
+- **x86 専用拡張**（ポート I/O・特権命令）: x86mov32 は持たず、その効果を共有 MMIO 上の PV-* レジスタで再表現。x86-host 実行層はこのラップ箇所だけ shim する。
+- **プラットフォーム契約**（マップ規約・fault・boot, §1c）: x86-host 実行層がページング等で敷く。
+
+movie86 は base + MMIO + PV-* を直接実装するリファレンス実装。conformance は §8 のテストで定義され、movie86 と x86-host 実行層の双方がそれを通すことで担保する。
+
+## 2. プロファイル（profile）
+
+実装もゲストも「movie86」ではなく **named profile** を宣言する。
+
+| profile | 含むもの | 用途 |
+|---|---|---|
+| **x86mov32-base** | §3 ISA + §4 レジスタ + §5 メモリ + §6 fault + §9 boot | 計算 + halt/exit。デバイス無し |
+| **x86mov32-pv-min** | base + §7.3 PV-CONSOLE + §7.4 PV-TIMER（割り込み無しの read） | 極小カーネルが print / tick poll |
+| **x86mov32-pv-kernel** | pv-min + §7.5 PV-CPU + §7.6 PV-IRQ + §7.7 PV-MMU + §6.3 trap 配送 | Linux/x86mov32 級（demand paging・割り込み・preemption）|
+| **x86mov32-compat-movfuscator** | base + 旧 movfuscator 互換（`int 0x80` syscall・SIGILL/SIGSEGV dispatch・segment-mov 経路）| 既存 movie86 資産（movfuscator-wasm 等）の後方互換 |
+
+**規則**:
+- 「X は x86mov32-pv-min を狙う」と profile 名で書く。movie86 は各 profile のリファレンス実装。
+- **x86-host 実行層**は profile ではなく「実 x86/qemu 上で指定 profile を供給する層」。同名 profile の §8 テストを通すか、通らない差分を conformance gap として文書化した場合のみ「その profile を host できる」と言える。
+- 互換ハック（§3.3）は **base に入れない**。`x86mov32-compat-movfuscator` に隔離する。
+
+## 3. ISA サブセット（base, 凍結）
+
+### 3.1 「mov-only」の定義
+
+**意味クラスではなくニーモニックで定義する。** base で許可されるのは以下のみ：
+
+- `mov`（全幅・全アドレッシングモード。ただし control register / segment register への mov は base では**不許可** — 特権操作は §7 で PV-MMIO mov に写像）
+- 制御転送の最小集合: `jmp rel32`(E9), `jmp r/m32`(FF /4), `call rel32`(E8), `ret`(C3), `push r32`(50–57), `pop r32`(58–5F)
+
+> 注: 純粋主義の「100% mov（jmp すら無し）」は本 spec の非目標。本機械は **mov + 最小制御転送**（movie86/llvm-mov の既定 "mov+jmp" に一致）。
+
+### 3.2 明示的に不許可（base）
+
+`cmp`/`jcc`/算術命令/FP/SIMD/REX/`lock` prefix/`int`/segment-mov/control-reg-mov。条件分岐・算術・FP は llvm-mov が mov 列に lower 済み（README ステージ 7a–7h）。
+
+### 3.3 互換ハックの隔離（base から除外）
+
+以下は **base ではなく `x86mov32-compat-movfuscator` profile** に属する。base / pv-* には現れない：
+
+- `int 0x80` syscall（base/pv では PV-MMIO + §9 の exit/halt が syscall/終了の唯一の機構）
+- SIGILL/SIGSEGV dispatch（`mov cs, r16` 経路を含む movfuscator trampoline）
+- segment register への mov
+
+### 3.4 EFLAGS
+
+base / pv に **観測可能な EFLAGS は存在しない**。許可命令はフラグを意味的に読まない（条件分岐は branchless dispatch に lower 済み）。実 x86 host 上では物理 EFLAGS が副作用で変わるが、x86mov32 プログラムはそれを観測してはならない（移植性条件）。trap frame に EFLAGS は含めない（§6.3）。
+
+## 4. レジスタ状態（base, 凍結）
+
+- 8 本の 32bit GPR（EAX..EDI）、EIP、ESP。
+- セグメントは概念として存在しない（flat。x86mov32 は segmentation を持たないアーキ）。x86 host 上では flat descriptor で実現するが、それは host 実装の都合。
+- EFLAGS は §3.4 の通り非観測。
+
+## 5. メモリモデル（base, 凍結）
+
+- フラット 32bit バイトアドレス空間、リトルエンディアン。
+- **マップ規約（Codex round-2 対応）**: x86mov32 は **明示的にマップされた領域のみ**有効。base/pv-min では「PT_LOAD + BSS（§9）+ 宣言された PV-MMIO 領域（§7）」だけがマップされ、それ以外へのアクセスは fault（§6.1）。bare-metal 物理メモリモデルではない。
+- **アラインメント**: 非整列アクセスは許可（`#AC` 相当は発生しない）。
+- **自己書き換えコード**: base では **不許可**（W^X 前提）。Linux のテストパッチ機構（alternatives / static-keys / jump-label / ftrace / kprobes / paravirt-patch）は §7.8 PV-TEXTPATCH か「対象 config で全テキスト改変を無効化」のいずれかで扱う（§10 未確定、ただし mainline 移植の必須検討事項）。
+- **MMIO は唯一の I/O 機構**（ポート I/O は持たない, §1b）。MMIO 領域（§7）アクセスは strong ordering（プログラム順, x86 の UC メモリ型相当 — この機構と順序は x86 と共有する）。UP・単一スレッド前提、投機・並べ替え無し。
+
+## 6. fault / trap 意味論（base, 凍結）
+
+「x86-like」とは **「許可された操作に対する同期 fault 境界が x86 と同じ」** の意であり、x86 protected-mode 挙動そのものではない（x86mov32 は独自アーキ）。
+
+### 6.1 同期 fault（base/pv-min, 凍結）
+
+| 条件 | x86mov32 base の挙動 |
+|---|---|
+| 未マップ領域（§5 のマップ外）への load/store | fault。ハンドラ未設定なら停止 |
+| 未マップ領域からの命令フェッチ / decode 不能・非許可エンコード | fault（停止） |
+| MMIO 不正オフセット / 不正方向（§7） | fault（停止）。silent success にしない（movie86 の trap-on-unknown を継承） |
+
+base/pv-min では除算命令を持たない（llvm-mov が mov 列に lower）ため除算 fault は発生しない。
+
+### 6.2 demand paging / page fault は pv-kernel の機能
+
+「ページ不在」は base/pv-min には存在しない（マップは静的）。**demand paging・COW・vmalloc fault・`copy_*_user` の fixup** は x86mov32 が pv-kernel で定義する page fault 機構（§7.7 PV-MMU + §6.3 配送）に依存する。Linux/x86mov32 はこれを使う。
+
+### 6.3 trap frame と配送（pv-kernel, **本 0.2 で形を確定** — Codex round-2 対応）
+
+非同期/同期 trap をハンドラに配送するとき、機械が積む **x86mov32 trap frame** を以下に確定する（`IRET` ABI 破壊を将来回避するため今決める）：
+
+```
+offset  field
++0x00   saved EIP        (fault した命令、または次命令)
++0x04   saved ESP
++0x08   EAX .. +0x24 EDI (8 GPR)
++0x28   fault_addr       (#PF 相当の CR2 等価。該当しない trap では 0)
++0x2C   error_code       (trap 種別 + アクセス種別ビット)
++0x30   trap_kind        (PAGE/ILLEGAL/MMIO/IRQ ...)
+```
+
+- **EFLAGS は含めない**（§3.4 と整合）。x86mov32 は x86 の exception frame を模さず、自前の frame を定義する。Linux/x86mov32 の `pt_regs` 相当はこの frame に合わせて新規定義する（arch/x86mov32 側の責務）。
+- `IRET`（§7.5）はこの frame から GPR/EIP/ESP を復帰する。
+- **RISC-V との対応**: `saved EIP`↔`sepc`、`trap_kind`/`error_code`↔`scause`、`fault_addr`↔`stval`、`IRET`↔`sret`。frame レイアウトの確定はこの既知モデルを踏襲しており、arch/riscv の trap 処理が移植の参考になる。
+
+## 7. PV-MMIO ABI
+
+特権操作のうち base ISA で表現できないものを、予約アドレスへの `mov` に写像する。CPU は依然 `mov` のみ実行し、機械が反応する。
+
+### 7.1 アドレスマップ
+
+```
+0x1FF0_0000 .. 0x1FF0_0FFF   PV-CPU        (pv-kernel)   IDT_BASE / INTR_MASK / IRET
+0x1FF0_1000 .. 0x1FF0_1FFF   PV-CONSOLE    (pv-min)      PUTC / STATUS
+0x1FF0_2000 .. 0x1FF0_2FFF   PV-TIMER      (pv-min)      TICKS / ONESHOT
+0x1FF0_3000 .. 0x1FF0_3FFF   PV-IRQ        (pv-kernel)   PENDING / EOI
+0x1FF0_4000 .. 0x1FF0_4FFF   PV-MMU        (pv-kernel)   PGDIR / FLUSH / FAULT_ADDR
+0x1FF0_5000 .. 0x1FF0_5FFF   PV-TEXTPATCH  (pv-kernel?)  予約（§7.8, §10 未確定）
+0x1FF0_FF00 .. 0x1FF0_FFFF   PV-DISCOVERY  (all)         MAGIC / VERSION / FEATURE_BITS
+0x1FFE_0000 .. 0x1FFE_0FFF   legacy ABI    (compat)      movfuscator 互換（write/exit 等）
+```
+全レジスタ 4byte 幅・自然整列アクセスのみ有効。範囲外/不正方向は fault（§6.1）。
+
+### 7.2 アクセス規約
+
+read 専用レジスタへの write、write 専用への read、未定義オフセットアクセスはいずれも fault。
+
+### 7.3 PV-CONSOLE（pv-min, 凍結候補）
+
+| off | 名前 | RW | 意味 |
+|---|---|---|---|
+| +0x00 | `PUTC` | W | 下位 8bit を 1 文字出力 |
+| +0x04 | `STATUS` | R | bit0=TX ready |
+
+### 7.4 PV-TIMER（pv-min は read のみ / 割り込みは pv-kernel）
+
+| off | 名前 | RW | 意味 |
+|---|---|---|---|
+| +0x00 | `TICKS` | R | 単調増加 tick（周波数は §7.9 VERSION 経由）|
+| +0x04 | `ONESHOT` | W | 次回タイマ通知までの tick。配送は §7.6（pv-kernel）|
+
+> RISC-V 対応: CLINT の `mtime`(=TICKS) / `mtimecmp`(=ONESHOT) とほぼ同型。実装・カーネル側ドライバとも CLINT を参考にできる。
+
+### 7.5 PV-CPU（pv-kernel, draft — 意味は L0.5 後に確定）
+
+`IDT_BASE`（trap ベクタ表 base）/ `INTR_MASK`（cli/sti 相当, 0=有効）/ `IRET`（§6.3 frame から復帰）。
+
+> RISC-V 対応: trap CSR（`stvec`=IDT_BASE, `sstatus.SIE`=INTR_MASK, `sret`=IRET）+ SBI（カーネルがプラットフォームに特権操作を依頼する役割）に相当。SBI の構造を PV-CPU の設計参考にする。
+
+### 7.6 PV-IRQ（pv-kernel, draft）
+
+`PENDING`(R, poll 型) / `EOI`(W)。配送: 初段 poll 型（純 mov）、preemption 要件が出たら強制ジャンプ型（trap frame §6.3 を積んで IDT 経由）を追加。
+
+> RISC-V 対応: CLINT(software/timer IRQ) + PLIC(外部 IRQ) に相当。irqchip ドライバは PLIC を参考にできる。
+
+### 7.7 PV-MMU（pv-kernel, draft）
+
+`PGDIR`(W, ページディレクトリ物理 base = ページング有効化)/ `FLUSH`(W, TLB 相当 invalidate)/ `FAULT_ADDR`(R, 直近 page fault のアドレス)。ページテーブル形式は **x86mov32 独自に定義**（x86 PTE 形式の流用可否は L0.5 で判断）。
+
+### 7.8 PV-TEXTPATCH（予約, §10 未確定）
+
+自己書き換え/テキストパッチを安全に行う操作。Linux の alternatives/static-keys/ftrace 等を許す場合に必要。代替は「対象 config で全テキスト改変を無効化」。L0.5 のインベントリでどちらが現実的か判定。
+
+### 7.9 PV-DISCOVERY（all, 凍結候補）
+
+`MAGIC`(R, 固定値) / `VERSION`(R, spec version) / `FEATURE_BITS`(R, 実装 profile の bit 集合)。実装/ゲスト双方が実行時に profile を確認できる。
+
+### 7.10 device tree によるハードウェア記述（pv-kernel）
+
+ハードウェア構成（メモリマップ・PV-CONSOLE/TIMER/IRQ/MMU の MMIO アドレス・割り込み番号）は **device tree（DTB）で記述し、カーネルは起動時に DTB から discover する**（riscv/arm 流）。
+
+- §7.1 のハードコード・アドレスマップは **デフォルト/リファレンス DT** という位置づけ。実アドレスは DTB が正。これにより §7.1 を凍結せずに済む（将来のアドレス変更が DT 差し替えで吸収できる）。
+- DTB は起動時にカーネルへ渡す（§9 boot 契約）。movie86・x86-host 実行層の双方が DTB を供給する。
+- PV-* デバイスには専用の DT compatible 文字列を割り当てる（例: `x86mov32,pv-console` / `x86mov32,pv-timer`）。ペリフェラルの *設計* は x86 の馴染んだデバイス（16550 UART 等）を参考にしてよいが、*記述・発見* は DT に統一する。
+
+## 8. conformance（一級の成果物 — 0.2 で必須リスト確定）
+
+各実装（movie86 / x86-host 実行層）は profile ごとに以下の **必須 fixture** を全て通すこと。通らない差分は conformance gap として明示文書化（沈黙の乖離を禁止）。
+
+**base 必須**:
+- decode whitelist（§3.1 許可命令が動く）/ blacklist（§3.2 非許可が fault）
+- 非整列 load/store が成功する
+- 未マップ data アクセスが fault する
+- 未マップ命令フェッチが fault する
+- 非許可エンコードが fault する
+- boot stack 形状（§9）/ exit・halt
+
+**pv-min 必須**: PUTC 出力 / STATUS / TICKS 単調増加 / MMIO 不正オフセット fault / DISCOVERY 各フィールド。
+
+**pv-kernel 必須**（0.2 で枠、意味確定後に具体化）: trap frame レイアウト（§6.3）/ IRET 往復 / INTR_MASK 効果 / page fault → FAULT_ADDR / PGDIR による VA→PA。
+
+## 9. boot / calling convention（base, 凍結）
+
+- ELF32 LE i386, `ET_EXEC`, 静的リンク。`PT_INTERP`/`PT_DYNAMIC` 不可。
+- 初期 EIP = `e_entry`。memory は PT_LOAD + BSS をゼロ初期化。これらと PV-MMIO 領域のみがマップされる（§5）。
+- **2 種類の boot 契約**（凍結）:
+  - **program boot**（base / pv-min）: 初期スタック = SysV ABI 最小像（argc=0, argv/envp/auxv=NULL）、ESP は argc を指す。極小プログラム・L1 極小カーネル用。
+  - **kernel boot**（pv-kernel）: エントリで **DTB 物理アドレスを `EBX` に**、boot magic を `EAX` に渡す（RISC-V の `a0=hartid, a1=dtb` に相当する規約を x86mov32 用に固定）。カーネルは DTB からハードウェアを discover する（§7.10）。今この規約を固定し、将来の破壊的変更を避ける。
+- 終了 = halt、または compat profile の legacy exit。
+
+## 10. version 方針と未確定事項
+
+- **凍結（0.x で変えない）**: §3 ISA、§4 レジスタ、§5 メモリ（マップ規約含む）、§6.1 同期 fault、§6.3 trap frame レイアウト、§9 boot。
+- **version 付きで進化**: §7.5–§7.7 の詳細意味論、ページテーブル形式、割り込み配送モデル、§7.8 テキストパッチ方針。
+- **0.3 への入力 = L0.5「Linux/x86mov32 feasibility kill-test」**（DESIGN.md）。単なる棚卸しでなく **kill-test** とする。最有力の致命要因は *命令選択ではなく* **inline asm の意味論** — `asm volatile`・`"memory"` clobber・`asm goto`・exception-table / fault fixup パターン。llvm-mov がコンパイラバリアと faultable asm/制御フロー fixup をモデル化できなければ、atomics 以前に詰む（UP atomics は当面ごまかせるが、barrier/fixup/asm-goto 契約はごまかせない）。

--- a/linux-mov/X86MOV32-SPEC.md
+++ b/linux-mov/X86MOV32-SPEC.md
@@ -65,13 +65,11 @@ movie86 は base + MMIO + PV-* を直接実装するリファレンス実装。c
 | **x86mov32-base** | §3 ISA + §4 レジスタ + §5 メモリ + §6 fault + §9 boot | 計算 + halt/exit。デバイス無し |
 | **x86mov32-pv-min** | base + §7.3 PV-CONSOLE + §7.4 PV-TIMER（割り込み無しの read） | 極小カーネルが print / tick poll |
 | **x86mov32-pv-kernel** | pv-min + §7.5 PV-CPU + §7.6 PV-IRQ + §7.7 PV-MMU + §6.3 trap 配送 | Linux/x86mov32 級（demand paging・割り込み・preemption）|
-| **x86mov32-compat-movfuscator** | base + 旧 movfuscator 互換（`int 0x80` syscall・SIGILL/SIGSEGV dispatch・segment-mov 経路）| 既存 movie86 資産の互換。**optional・best-effort**（design stance 参照） |
 
 **規則**:
 - 「X は x86mov32-pv-min を狙う」と profile 名で書く。movie86 は各 profile のリファレンス実装。
 - **x86-host 実行層**は profile ではなく「実 x86/qemu 上で指定 profile を供給する層」。同名 profile の §8 テストを通すか、通らない差分を conformance gap として文書化した場合のみ「その profile を host できる」と言える。
-- 互換ハック（§3.3）は **base に入れない**。`x86mov32-compat-movfuscator` に隔離する。
-- **design stance: movie86 の AS-IS 仕様は維持制約ではない**。movie86 を x86mov32 のリファレンス機械へ再形成する際、現行の userspace-runner 挙動・movfuscator 実行・寛容な flat メモリ・`0x1FFE_0000` ABI を保存する義務はない。`x86mov32-compat-movfuscator` は **optional な legacy モード**であって x86mov32 の設計を縛らない。既存資産（movfuscator-wasm / explorer 等）の互換は best-effort で、必要になった時だけ legacy モードとして供給する。
+- **design stance: movie86 の AS-IS 仕様の互換は非ゴール（best-effort ですらない）**。movie86 を x86mov32 のリファレンス機械へ再形成する際、現行の userspace-runner 挙動・movfuscator 実行・寛容な flat メモリ・`0x1FFE_0000` ABI を保存する義務は一切ない。旧 movfuscator 互換（`int 0x80`・SIGILL/SIGSEGV dispatch・segment-mov）は **x86mov32 の一部ではない**（§3.3）。既存資産（movfuscator-wasm / explorer 等）が壊れることは許容する。
 
 ## 3. ISA サブセット（base, 凍結）
 
@@ -88,11 +86,11 @@ movie86 は base + MMIO + PV-* を直接実装するリファレンス実装。c
 
 `cmp`/`jcc`/算術命令/FP/SIMD/REX/`lock` prefix/`int`/segment-mov/control-reg-mov。条件分岐・算術・FP は llvm-mov が mov 列に lower 済み（README ステージ 7a–7h）。
 
-### 3.3 互換ハックの隔離（base から除外）
+### 3.3 x86mov32 に含まれないもの（旧 movfuscator 機構）
 
-以下は **base ではなく `x86mov32-compat-movfuscator` profile** に属する。base / pv-* には現れない：
+以下は **x86mov32 の一部ではない**（base / pv-* いずれにも現れず、互換も非ゴール §2）：
 
-- `int 0x80` syscall（base/pv では PV-MMIO + §9 の exit/halt が syscall/終了の唯一の機構）
+- `int 0x80` syscall（x86mov32 では PV-MMIO + §9 の exit/halt が syscall/終了の唯一の機構）
 - SIGILL/SIGSEGV dispatch（`mov cs, r16` 経路を含む movfuscator trampoline）
 - segment register への mov
 
@@ -167,8 +165,8 @@ offset  field
 0x1FF0_4000 .. 0x1FF0_4FFF   PV-MMU        (pv-kernel)   PGDIR / FLUSH / FAULT_ADDR
 0x1FF0_5000 .. 0x1FF0_5FFF   PV-TEXTPATCH  (pv-kernel?)  予約（§7.8, §10 未確定）
 0x1FF0_FF00 .. 0x1FF0_FFFF   PV-DISCOVERY  (all)         MAGIC / VERSION / FEATURE_BITS
-0x1FFE_0000 .. 0x1FFE_0FFF   legacy ABI    (compat)      movfuscator 互換（write/exit 等）
 ```
+（旧 movfuscator の `0x1FFE_0000` ABI は x86mov32 では予約しない。§7.1 の窓は自由に設計してよい。）
 全レジスタ 4byte 幅・自然整列アクセスのみ有効。範囲外/不正方向は fault（§6.1）。
 
 ### 7.2 アクセス規約
@@ -248,7 +246,7 @@ read 専用レジスタへの write、write 専用への read、未定義オフ�
 - **2 種類の boot 契約**（凍結）:
   - **program boot**（base / pv-min）: 初期スタック = SysV ABI 最小像（argc=0, argv/envp/auxv=NULL）、ESP は argc を指す。極小プログラム・L1 極小カーネル用。**boot stack は実装定義の固定領域**（base/top と extent を実装が決め、§5 のマップ集合に含める）。L0 テストの決定性のため、この領域の base/サイズを実装で固定する。
   - **kernel boot**（pv-kernel）: エントリで **DTB 物理アドレスを `EBX` に**、boot magic を `EAX` に渡す（RISC-V の `a0=hartid, a1=dtb` に相当する規約を x86mov32 用に固定）。カーネルは DTB からハードウェアを discover する（§7.10）。今この規約を固定し、将来の破壊的変更を避ける。
-- 終了 = halt、または compat profile の legacy exit。
+- 終了 = halt（PV exit / halt 機構, §7）。
 
 ## 10. version 方針と未確定事項
 


### PR DESCRIPTION
Linux を mov ターゲットへ移植する取り組みの **設計フェーズ一式**（実装前・コード変更なし、`linux-mov/` の設計文書 4 本）。movie86 / llvm-mov の延長として、新アーキ `arch/x86mov32` を起こす方向で設計を固めた。

## 中心となる再整理

- **x86mov32 を独立した base ISA として定義**し、普通の x86 を「x86mov32 + 大量の拡張」と位置づける（RISC-V の `RV32I` + 拡張と同じモジュラ ISA 観）。movie86 はリファレンス実装、実 x86 はエンコーディングを実行できる host。
- **MMIO 機構は x86 と共有**、特権命令とポート I/O だけが x86 専用。x86mov32 は MMIO-only I/O（特権効果は PV-MMIO への mov に写像）。
- Linux 移植は arch/x86 ではなく **arch/riscv(rv32) を主 template** に。trap frame↔sepc/scause/stval、PV-TIMER↔CLINT、PV-IRQ↔PLIC、PV-CPU↔SBI、device tree。

## 文書

- **X86MOV32-SPEC.md** (v0.2-draft): 正典の機械定義。ISA サブセット / メモリ / fault / trap frame / PV-MMIO / 4 プロファイル / conformance / boot 契約。
- **X86-DELTA.md**: 特権命令の要否分析。mov はチューリング完全ゆえ真に irreducible なのは「native/未計装/低遅延なコードへの強制介入」と外部エージェントの latch のみ。MMU/保護は原理 reducible だが実用で PV 化。「特権パス = mov 列」の worked example。
- **DESIGN.md**: ロードマップ L0–L8。x86 起動経路（§3.5）= 薄い x86-host substrate（OpenSBI 相当）上で計算は near-native。substrate 自体も mov-heavy + 最小非-mov スタブに。
- **L0.5-KILLTEST.md**: 実 Linux + arch/riscv に対する feasibility kill-test。**判定 SURVIVES**（二者独立検証）。最小 config にカーネル側 config BLOCKER なし。任意 inline asm は first boot 不要。

## 検証

smart-friend (codex/gpt-5.5) による設計レビュー **4 ラウンド** + feasibility kill-test の **二者独立検証**を反映済み。主要な訂正（fault 意味論 x86-like 化、互換ハックの compat profile 隔離、substrate 非-mov 核 = M-set の上位集合、trap-stack ABI 追加など）を取り込み。

実装はまだ。次は L0（movie86 に PV-CONSOLE を TDD 追加）から。

🤖 Generated with [Claude Code](https://claude.com/claude-code)